### PR TITLE
Adopt v-prefixed three-part release tags

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: '$RESOLVED_VERSION 🌈'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "net.nightvision"
-version = "2.2"
+version = "2.2.0"
 
 
 repositories {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
   ]]></description>
 
   <change-notes><![CDATA[
-    <h3>2.2</h3>
+    <h3>2.2.0</h3>
     <b>Added</b>
     <ul>
       <li>PHP and Go language support for API Discovery</li>


### PR DESCRIPTION
Sets the tag convention before the first release creates the baseline that Release Drafter increments from. The repo has no tags yet, and its `tag-template` emitted a bare version while the VS Code plugin already tags `v1.0.4` style, so the two would have diverged permanently from v2.2.0 onward.

## Implementation

- **`v` prefix on the release templates**: `tag-template` and `name-template` now emit `v$RESOLVED_VERSION`, matching the VS Code plugin.
- **Plugin version to `2.2.0`**: keeps the tag and the published artifact in step rather than tagging `v2.2.0` against a `2.2` Marketplace listing. `2.2.0` still orders above the published `2.1`.
- **Change-notes heading to `2.2.0`**: the IDE Plugin Manager entry matches the shipped version.

## Verification

`./gradlew build verifyPlugin` passes, and the version reaches the artifact: the distributable is `intellij-idea-nightvision-2.2.0.zip` and its patched `plugin.xml` carries `<version>2.2.0</version>`.

Nothing in `publish.yml` or `build.gradle.kts` reads the git tag, so the tag name never affected which version ships; this change is about the two agreeing.