### PR TITLE
Publish the signed archive, not the unsigned one

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,13 @@ jobs:
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+      # publishPlugin depends on signPlugin, and signPlugin reads its certificate
+      # and key from the environment. Without them here it is skipped, and the
+      # plugin is published unsigned with the build still reporting success.
       - name: Publish to Marketplace
         run: ./gradlew publishPlugin
         env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,5 +58,10 @@ tasks {
 
   publishPlugin {
     token.set(System.getenv("PUBLISH_TOKEN"))
+    // By default publishPlugin picks its archive on signPlugin's didWork flag, which
+    // is false whenever signing is skipped, up to date, or restored from the build
+    // cache. In those cases it silently uploads the unsigned archive and still
+    // reports success. Point it at the signed archive so signing cannot be lost.
+    archiveFile.set(signPlugin.flatMap { it.signedArchiveFile })
   }
 }


### PR DESCRIPTION
`publishPlugin` chooses which archive to upload from `signPlugin`'s `didWork` flag, falling back to `buildPlugin`'s unsigned archive when it is false. It logs nothing and reports success either way.

`didWork` is false in three ordinary cases:

- signing skipped for want of credentials
- `signPlugin` `UP-TO-DATE` because an earlier step already ran it
- `signPlugin` `FROM-CACHE`, which this repo invites via `org.gradle.caching = true`

v2.2.0 was published unsigned through the first of these: the signing credentials were set only on the `Sign plugin` step, so during `publishPlugin` the task was skipped and the unsigned archive went up.

## Implementation

- **`archiveFile` pinned to the signed archive**: `publishPlugin.archiveFile` now points at `signPlugin.signedArchiveFile` so the choice cannot depend on execution history, cache state, or step ordering.
- **Signing secrets added to the `Publish to Marketplace` step**: `signPlugin` runs as a dependency of `publishPlugin` and needs them there. Without them the task is skipped, the signed archive is never produced, and publish now fails loudly instead of shipping unsigned.

## Verification

Measured against the real credentials, reproducing each CI shape:

| signPlugin state | `didWork` | archive chosen (before) | archive chosen (after) |
|---|---|---|---|
| executes | true | signed | signed |
| `UP-TO-DATE` | false | **unsigned** | signed |
| `FROM-CACHE` | false | **unsigned** | signed |
| skipped, no creds | false | **unsigned** | publish fails loudly |

The middle two are what made the credentials-only fix insufficient: a separate `Sign plugin` step leaves `signPlugin` `UP-TO-DATE` in the publish invocation, so `didWork` is false and the unsigned archive still wins. With `archiveFile` set explicitly, `publishPlugin.archiveFile` resolves to `intellij-idea-nightvision-2.2.0-signed.zip` even with `didWork` false.

`build verifyPlugin` passes and `signPlugin` still produces a signed archive.

## Out-of-scope

v2.2.0 is already approved and live on the Marketplace, published unsigned. It is functional, since the Marketplace signs plugins for distribution itself, so this does not warrant pulling the release. The next version published after this merge will carry the author signature.