### PR TITLE
Fix scans killed mid-run and align the plugin with VS Code v1.0.7

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,9 +6,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
     environment: jetbrains-marketplace
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Scans without an authentication no longer pass the CLI an empty `--auth` value
 - Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot
 - Scan list vulnerability counts are color-coded by severity, and name the severity on hover
+- "Open in browser" links open the record they name instead of the NightVision home page
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.3.0]
+
 ### Fixed
 
 - Scans no longer stop after 30 seconds: the CLI is given a deadline to start a scan, not to finish one, so a scan runs for as long as it takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Switching project no longer freezes the IDE or reports an "IDE error": the CLI runs in the background and the dropdown is disabled while it does
 - Selecting the project that is already current is no longer treated as a failed switch
 - Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot
-- Scan list vulnerability counts are color-coded by severity, and name the severity on hover
+- Scan list vulnerability counts are color-coded by severity, and one hover names every severity with its count
 - "Open in browser" links open the record they name instead of the NightVision home page
 
 ## [2.2.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
 - Scans without an authentication no longer pass the CLI an empty `--auth` value
 - Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot
+- Scan list vulnerability counts are color-coded by severity, and name the severity on hover
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Scans no longer stop after 30 seconds: the CLI is given a deadline to start a scan, not to finish one, so a scan runs for as long as it takes
+- A scan that fails to start now reports the reason from the CLI instead of "Some error happened when creating your scan"
+- The create-scan page stays put until the scan has started, so a failure is visible rather than reported on a screen you have already left
+- The create-scan page says "Starting scan, please wait..." while the CLI starts the scan, which can take up to two minutes
+- Project, target and authentication creation likewise report the CLI's reason
+- The CLI update prompt explains itself on the Overview screen, naming the version installed, the version needed and the binary the plugin resolved
+- The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
+- Scans without an authentication no longer pass the CLI an empty `--auth` value
+
 ## [2.2.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The CLI update prompt explains itself on the Overview screen, naming the version installed, the version needed and the binary the plugin resolved
 - The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
 - Scans without an authentication no longer pass the CLI an empty `--auth` value
+- Authentication can be left unset on a scan even when the project has authentications; it now defaults to none rather than to the first in the list
 - Switching project no longer freezes the IDE or reports an "IDE error": the CLI runs in the background and the dropdown is disabled while it does
 - Selecting the project that is already current is no longer treated as a failed switch
 - Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The CLI update prompt explains itself on the Overview screen, naming the version installed, the version needed and the binary the plugin resolved
 - The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
 - Scans without an authentication no longer pass the CLI an empty `--auth` value
+- Switching project no longer freezes the IDE or reports an "IDE error": the CLI runs in the background and the dropdown is disabled while it does
 - Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot
 - Scan list vulnerability counts are color-coded by severity, and name the severity on hover
 - "Open in browser" links open the record they name instead of the NightVision home page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - The create-scan page stays put until the scan has started, so a failure is visible rather than reported on a screen you have already left
 - The create-scan page says "Starting scan, please wait..." while the CLI starts the scan, which can take up to two minutes
 - Project, target and authentication creation likewise report the CLI's reason
+- A command that fails with an error code reports it in the same words as one that fails silently, without an exit code the user cannot act on
 - The CLI update prompt explains itself on the Overview screen, naming the version installed, the version needed and the binary the plugin resolved
 - The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
 - Scans without an authentication no longer pass the CLI an empty `--auth` value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The CLI update prompt explains itself on the Overview screen, naming the version installed, the version needed and the binary the plugin resolved
 - The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
 - Scans without an authentication no longer pass the CLI an empty `--auth` value
+- Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The minimum CLI version is 0.15.0, the oldest able to scan a target that is not reachable from the internet
 - Scans without an authentication no longer pass the CLI an empty `--auth` value
 - Switching project no longer freezes the IDE or reports an "IDE error": the CLI runs in the background and the dropdown is disabled while it does
+- Selecting the project that is already current is no longer treated as a failed switch
 - Error messages can be selected and copied, so a CLI failure can be pasted into a support ticket instead of retyped from a screenshot
 - Scan list vulnerability counts are color-coded by severity, and name the severity on hover
 - "Open in browser" links open the record they name instead of the NightVision home page

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "net.nightvision"
-version = "2.2.1"
+version = "2.3.0"
 
 
 repositories {
@@ -39,9 +39,9 @@ intellijPlatform {
 }
 
 // CHANGELOG.md is the single source of truth for release notes. patchPluginXml
-// (below) renders the current version's section into the plugin change-notes,
-// and patchChangelog rolls the Unreleased section into a dated version section
-// at release time.
+// (below) renders the current version's section into the plugin change-notes.
+// No workflow runs patchChangelog, so the Unreleased section is renamed to the
+// new version by hand in the same commit that bumps the version here.
 changelog {
   version.set(project.version.toString())
   repositoryUrl.set("https://github.com/nvsecurity/nightvision-intellij")

--- a/src/main/java/net/nightvision/plugin/InstallCLIScreen.form
+++ b/src/main/java/net/nightvision/plugin/InstallCLIScreen.form
@@ -21,7 +21,7 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="841df" class="javax.swing.JLabel" binding="errorMessageLabel">
+      <component id="841df" class="com.intellij.ui.components.JBLabel" binding="errorMessageLabel">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/src/main/java/net/nightvision/plugin/InstallCLIScreen.java
+++ b/src/main/java/net/nightvision/plugin/InstallCLIScreen.java
@@ -1,5 +1,7 @@
 package net.nightvision.plugin;
 
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 import com.intellij.openapi.project.Project;
 import net.nightvision.plugin.scans.ScansScreen;
@@ -16,7 +18,7 @@ import java.util.List;
 public class InstallCLIScreen extends Screen {
     private JButton installCLIButton;
     private JPanel installCLIPanel;
-    private JLabel errorMessageLabel;
+    private JBLabel errorMessageLabel;
 
     public JPanel getLoginPanel() {
         return installCLIPanel;
@@ -27,6 +29,7 @@ public class InstallCLIScreen extends Screen {
 
         installCLIPanel.setBorder(JBUI.Borders.empty(8));
 
+        makeSelectable(errorMessageLabel);
         errorMessageLabel.setVisible(false);
 
         addButtonPadding(installCLIButton, 6);

--- a/src/main/java/net/nightvision/plugin/LoginScreen.form
+++ b/src/main/java/net/nightvision/plugin/LoginScreen.form
@@ -29,7 +29,7 @@
           <text value="Update CLI"/>
         </properties>
       </component>
-      <component id="9845b" class="javax.swing.JLabel" binding="errorMessageLabel">
+      <component id="9845b" class="com.intellij.ui.components.JBLabel" binding="errorMessageLabel">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/src/main/java/net/nightvision/plugin/LoginScreen.java
+++ b/src/main/java/net/nightvision/plugin/LoginScreen.java
@@ -14,6 +14,8 @@ import net.nightvision.plugin.services.ProjectService;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.util.ui.JBUI;
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 import java.awt.*;
 
@@ -21,7 +23,7 @@ public class LoginScreen extends Screen {
     private JButton loginButton;
     private JPanel loginPanel;
     private JButton updateCLIButton;
-    private JLabel errorMessageLabel;
+    private JBLabel errorMessageLabel;
 
     public JPanel getLoginPanel() {
         return loginPanel;
@@ -59,6 +61,7 @@ public class LoginScreen extends Screen {
         addButtonPadding(loginButton, 6);
         loginPanel.setBorder(JBUI.Borders.empty(8));
 
+        makeSelectable(errorMessageLabel);
         errorMessageLabel.setVisible(false);
         updateCLIButton.setVisible(false);
 

--- a/src/main/java/net/nightvision/plugin/LoginScreen.java
+++ b/src/main/java/net/nightvision/plugin/LoginScreen.java
@@ -34,10 +34,13 @@ public class LoginScreen extends Screen {
                 try {
                     String cliVersion = CommandRunnerService.INSTANCE.getCLIVersion();
                     boolean shouldUpdateCLI = InstallCLIService.INSTANCE.shouldUpdateCLI(cliVersion);
+                    // Resolved here rather than on the EDT: it walks PATH and
+                    // stats each candidate.
+                    String cliPath = shouldUpdateCLI ? CommandRunnerService.INSTANCE.resolveCliPath() : null;
 
                     ApplicationManager.getApplication().invokeLater(() -> {
                         if (shouldUpdateCLI) {
-                            setupUpdateButton();
+                            setupUpdateButton(cliVersion, cliPath);
                         } else {
                             updateCLIButton.setVisible(false);
                         }
@@ -127,8 +130,10 @@ public class LoginScreen extends Screen {
         }
     }
 
-    private void setupUpdateButton() {
+    private void setupUpdateButton(String cliVersion, String cliPath) {
         updateCLIButton.setVisible(true);
+        updateCLIButton.setToolTipText(
+                cliUpdateTooltip(cliVersion, cliPath, Constants.CLI_VERSION));
         updateCLIButton.addActionListener(e -> {
             errorMessageLabel.setVisible(false);
             errorMessageLabel.setText("");

--- a/src/main/java/net/nightvision/plugin/OverviewScreen.form
+++ b/src/main/java/net/nightvision/plugin/OverviewScreen.form
@@ -109,7 +109,7 @@
           <text value="Update NightVision CLI"/>
         </properties>
       </component>
-      <component id="4c1e0" class="javax.swing.JLabel" binding="updateMessageLabel">
+      <component id="4c1e0" class="com.intellij.ui.components.JBLabel" binding="updateMessageLabel">
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -117,7 +117,7 @@
           <text value="&lt;CLI update message&gt;"/>
         </properties>
       </component>
-      <component id="7b2a6" class="javax.swing.JLabel" binding="errorMessageLabel">
+      <component id="7b2a6" class="com.intellij.ui.components.JBLabel" binding="errorMessageLabel">
         <constraints>
           <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/src/main/java/net/nightvision/plugin/OverviewScreen.form
+++ b/src/main/java/net/nightvision/plugin/OverviewScreen.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.nightvision.plugin.OverviewScreen">
-  <grid id="27dc6" binding="overviewPanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="6">
+  <grid id="27dc6" binding="overviewPanel" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="6">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="428"/>
@@ -25,7 +25,7 @@
       </vspacer>
       <vspacer id="7ea77">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="e289f" class="javax.swing.JButton" binding="apiAndWebSecurityButton">
@@ -103,15 +103,23 @@
       </grid>
       <component id="bac6d" class="javax.swing.JButton" binding="updateCLIButton" default-binding="true">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Update CLI"/>
+          <text value="Update NightVision CLI"/>
+        </properties>
+      </component>
+      <component id="4c1e0" class="javax.swing.JLabel" binding="updateMessageLabel">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="&lt;CLI update message&gt;"/>
         </properties>
       </component>
       <component id="7b2a6" class="javax.swing.JLabel" binding="errorMessageLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <foreground color="-65536"/>

--- a/src/main/java/net/nightvision/plugin/OverviewScreen.java
+++ b/src/main/java/net/nightvision/plugin/OverviewScreen.java
@@ -31,6 +31,7 @@ public class OverviewScreen extends Screen {
     private JButton authenticationsButton;
     private JButton projectsButton;
     private JButton updateCLIButton;
+    private JLabel updateMessageLabel;
     private JLabel errorMessageLabel;
 
     public JPanel getOverviewPanel() {
@@ -46,8 +47,13 @@ public class OverviewScreen extends Screen {
 
     }
 
-    private void setupUpdateButton() {
+    private void setupUpdateButton(String cliVersion, String cliPath) {
         updateCLIButton.setVisible(true);
+        updateCLIButton.setToolTipText(
+                cliUpdateTooltip(cliVersion, cliPath, Constants.CLI_VERSION));
+        updateMessageLabel.setText(
+                cliUpdateMessage(cliVersion, cliPath, Constants.CLI_VERSION));
+        updateMessageLabel.setVisible(true);
         updateCLIButton.addActionListener(e -> {
             errorMessageLabel.setVisible(false);
             errorMessageLabel.setText("");
@@ -64,6 +70,8 @@ public class OverviewScreen extends Screen {
         overviewPanel.setBorder(JBUI.Borders.empty(8));
 
         updateCLIButton.setVisible(false);
+        updateMessageLabel.setForeground(JBColor.RED);
+        updateMessageLabel.setVisible(false);
         errorMessageLabel.setVisible(false);
 
         new Task.Backgroundable(project, "Checking CLI Version", false) {
@@ -72,12 +80,16 @@ public class OverviewScreen extends Screen {
                 try {
                     String cliVersion = CommandRunnerService.INSTANCE.getCLIVersion();
                     boolean shouldUpdateCLI = InstallCLIService.INSTANCE.shouldUpdateCLI(cliVersion);
+                    // Resolved here rather than on the EDT: it walks PATH and
+                    // stats each candidate.
+                    String cliPath = shouldUpdateCLI ? CommandRunnerService.INSTANCE.resolveCliPath() : null;
 
                     ApplicationManager.getApplication().invokeLater(() -> {
                         if (shouldUpdateCLI) {
-                            setupUpdateButton();
+                            setupUpdateButton(cliVersion, cliPath);
                         } else {
                             updateCLIButton.setVisible(false);
+                            updateMessageLabel.setVisible(false);
                         }
                     });
                 } catch (ProcessNotCreatedException ex) {
@@ -170,11 +182,12 @@ public class OverviewScreen extends Screen {
             try {
                 get();
                 updateCLIButton.setVisible(false);
+                updateMessageLabel.setVisible(false);
             } catch (Exception ex) {
                 errorMessageLabel.setText(ex.toString());
                 errorMessageLabel.setVisible(true);
                 updateCLIButton.setEnabled(true);
-                updateCLIButton.setText("Update CLI");
+                updateCLIButton.setText("Update NightVision CLI");
             }
         }
     }

--- a/src/main/java/net/nightvision/plugin/OverviewScreen.java
+++ b/src/main/java/net/nightvision/plugin/OverviewScreen.java
@@ -1,5 +1,7 @@
 package net.nightvision.plugin;
 
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 
 import com.intellij.execution.process.ProcessNotCreatedException;
@@ -31,8 +33,8 @@ public class OverviewScreen extends Screen {
     private JButton authenticationsButton;
     private JButton projectsButton;
     private JButton updateCLIButton;
-    private JLabel updateMessageLabel;
-    private JLabel errorMessageLabel;
+    private JBLabel updateMessageLabel;
+    private JBLabel errorMessageLabel;
 
     public JPanel getOverviewPanel() {
         return overviewPanel;
@@ -70,6 +72,7 @@ public class OverviewScreen extends Screen {
         overviewPanel.setBorder(JBUI.Borders.empty(8));
 
         updateCLIButton.setVisible(false);
+        makeSelectable(updateMessageLabel, errorMessageLabel);
         updateMessageLabel.setForeground(JBColor.RED);
         updateMessageLabel.setVisible(false);
         errorMessageLabel.setVisible(false);

--- a/src/main/java/net/nightvision/plugin/Screen.java
+++ b/src/main/java/net/nightvision/plugin/Screen.java
@@ -1,6 +1,7 @@
 package net.nightvision.plugin;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.JBUI;
 
 import javax.swing.*;
@@ -42,23 +43,43 @@ public abstract class Screen {
      * first line, which is rarely the line carrying the reason (NV-4827).
      */
     protected static String asWrappedHtml(String text) {
-        return wrapHtml(escapeHtml(text));
+        String[] lines = text.split("\n", -1);
+        for (int i = 0; i < lines.length; i++) {
+            lines[i] = escapeHtml(lines[i]);
+        }
+        return wrapHtml(lines);
     }
 
     // Text the caller does not control, made safe to drop into a label's HTML.
+    // Line breaks are not this method's business: wrapHtml gives each line its
+    // own element, so callers split first and escape each line.
     private static String escapeHtml(String text) {
         return text
                 .replace("&", "&amp;")
                 .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\n", "<br>");
+                .replace(">", "&gt;");
     }
 
-    // Caps the label at a readable width so long text wraps instead of
-    // stretching the tool window.
-    private static String wrapHtml(String bodyHtml) {
+    /**
+     * Assembles one label's worth of HTML, a block element per line, capped at
+     * a readable width so long text wraps instead of stretching the tool
+     * window.
+     *
+     * The lines are blocks rather than <br> separators because these labels are
+     * selectable (see makeSelectable) and the two copy differently: Swing turns
+     * a <br> into a space, so a three-line CLI failure pasted into a support
+     * ticket would arrive as one run-on line, while a block element copies as a
+     * real newline.
+     */
+    private static String wrapHtml(String... lineHtml) {
+        StringBuilder body = new StringBuilder();
+        for (String line : lineHtml) {
+            // An empty div collapses to nothing, so a blank line keeps a <br>
+            // to hold its height.
+            body.append("<div>").append(line.isEmpty() ? "<br>" : line).append("</div>");
+        }
         return "<html><body style='width: " + JBUI.scale(MESSAGE_WRAP_WIDTH) + "px'>"
-                + bodyHtml + "</body></html>";
+                + body + "</body></html>";
     }
 
     /**
@@ -95,16 +116,34 @@ public abstract class Screen {
      * find out; an out-of-date CLI is worth saying on the screen (NV-4873).
      */
     protected static String cliUpdateMessage(String version, String resolvedPath, String required) {
-        StringBuilder html = new StringBuilder();
-        html.append("<b>You have version ")
-                .append(escapeHtml(version.isBlank() ? "(unknown)" : version))
-                .append(" of the NightVision CLI, but the plugin requires version ")
-                .append(escapeHtml(required))
-                .append(" to be fully operational.</b>");
-        if (resolvedPath != null && !resolvedPath.isBlank()) {
-            html.append("<br>Using ").append(escapeHtml(resolvedPath));
+        String mismatch = "<b>You have version "
+                + escapeHtml(version.isBlank() ? "(unknown)" : version)
+                + " of the NightVision CLI, but the plugin requires version "
+                + escapeHtml(required)
+                + " to be fully operational.</b>";
+        if (resolvedPath == null || resolvedPath.isBlank()) {
+            return wrapHtml(mismatch);
         }
-        return wrapHtml(html.toString());
+        return wrapHtml(mismatch, "Using " + escapeHtml(resolvedPath));
+    }
+
+    /**
+     * Lets the user select and copy a message label's text. Swing draws a
+     * JLabel as an image with no caret and no selection, so a CLI failure shown
+     * in one can only be screenshotted or retyped, which is the wrong thing to
+     * ask of someone reporting a problem to support. setCopyable swaps in a
+     * text component that renders the same HTML and allows selection.
+     */
+    protected static void makeSelectable(JBLabel... labels) {
+        for (JBLabel label : labels) {
+            // Ordered: setCopyable builds the editor pane's stylesheet once and
+            // reads this flag while doing it, and the flag's setter does not
+            // restyle. Left at its default the rule carries white-space:nowrap
+            // on body, the element asWrappedHtml caps the width of, so a long
+            // CLI line would run off the side of the tool window.
+            label.setAllowAutoWrapping(true);
+            label.setCopyable(true);
+        }
     }
 
     // pad is scaled, so the padding tracks the IDE's display scaling the way the

--- a/src/main/java/net/nightvision/plugin/Screen.java
+++ b/src/main/java/net/nightvision/plugin/Screen.java
@@ -62,6 +62,16 @@ public abstract class Screen {
     }
 
     /**
+     * The reported text of a failure, wrapped for a JLabel. An exception with
+     * no message of its own falls back to its toString, so the label never
+     * renders blank where a reason was expected.
+     */
+    protected static String asWrappedError(Throwable t) {
+        String message = t.getMessage();
+        return asWrappedHtml(message == null || message.isBlank() ? t.toString() : message);
+    }
+
+    /**
      * Tooltip for the Update CLI button, naming the CLI it means. The plugin
      * prepends its own install directory to PATH, so the binary it runs is not
      * necessarily the one the user's terminal resolves; without the path here,

--- a/src/main/java/net/nightvision/plugin/Screen.java
+++ b/src/main/java/net/nightvision/plugin/Screen.java
@@ -18,6 +18,39 @@ public abstract class Screen {
         this.mainWindowFactory = project.getService(MainWindowService.class).getWindowFactory();
     }
 
+    // Width a wrapped error message is capped at, so a long CLI line wraps
+    // instead of stretching the tool window.
+    protected static final int MESSAGE_WRAP_WIDTH = 320;
+
+    /**
+     * Whether [panel] is still mounted in the tool window.
+     *
+     * Navigation replaces the tool window's contents wholesale, so a screen the
+     * user has left has no parent, while one whose tool window is merely hidden,
+     * collapsed or unselected still does. AWT visibility is the wrong test:
+     * isShowing() also goes false when the user switches to another tool window,
+     * and a background result arriving then is still wanted.
+     */
+    protected static boolean isMounted(JComponent panel) {
+        return panel.getParent() != null;
+    }
+
+    /**
+     * Renders multi-line text in a JLabel. Swing labels draw plain text on one
+     * line and ignore newlines, so CLI output shown to the user is escaped and
+     * converted to HTML. Without this a reported failure is truncated to its
+     * first line, which is rarely the line carrying the reason (NV-4827).
+     */
+    protected static String asWrappedHtml(String text) {
+        String escaped = text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\n", "<br>");
+        return "<html><body style='width: " + JBUI.scale(MESSAGE_WRAP_WIDTH) + "px'>"
+                + escaped + "</body></html>";
+    }
+
     // pad is scaled, so the padding tracks the IDE's display scaling the way the
     // button's own text and icon do.
     protected static void addButtonPadding(JButton button, int pad) {

--- a/src/main/java/net/nightvision/plugin/Screen.java
+++ b/src/main/java/net/nightvision/plugin/Screen.java
@@ -42,13 +42,59 @@ public abstract class Screen {
      * first line, which is rarely the line carrying the reason (NV-4827).
      */
     protected static String asWrappedHtml(String text) {
-        String escaped = text
+        return wrapHtml(escapeHtml(text));
+    }
+
+    // Text the caller does not control, made safe to drop into a label's HTML.
+    private static String escapeHtml(String text) {
+        return text
                 .replace("&", "&amp;")
                 .replace("<", "&lt;")
                 .replace(">", "&gt;")
                 .replace("\n", "<br>");
+    }
+
+    // Caps the label at a readable width so long text wraps instead of
+    // stretching the tool window.
+    private static String wrapHtml(String bodyHtml) {
         return "<html><body style='width: " + JBUI.scale(MESSAGE_WRAP_WIDTH) + "px'>"
-                + escaped + "</body></html>";
+                + bodyHtml + "</body></html>";
+    }
+
+    /**
+     * Tooltip for the Update CLI button, naming the CLI it means. The plugin
+     * prepends its own install directory to PATH, so the binary it runs is not
+     * necessarily the one the user's terminal resolves; without the path here,
+     * "your CLI is out of date" gives no way to tell which CLI is meant
+     * (NV-4873).
+     */
+    protected static String cliUpdateTooltip(String version, String resolvedPath, String required) {
+        StringBuilder text = new StringBuilder();
+        text.append("NightVision CLI ").append(version.isBlank() ? "(unknown version)" : version);
+        if (resolvedPath != null && !resolvedPath.isBlank()) {
+            text.append("\n").append(resolvedPath);
+        }
+        text.append("\nThe plugin needs ").append(required).append(" or newer.");
+        return asWrappedHtml(text.toString());
+    }
+
+    /**
+     * The warning shown under the Update CLI button, wording it as the VS Code
+     * plugin does under its own. The tooltip above carries the same facts, but
+     * only reaches a user who already suspects something is wrong and hovers to
+     * find out; an out-of-date CLI is worth saying on the screen (NV-4873).
+     */
+    protected static String cliUpdateMessage(String version, String resolvedPath, String required) {
+        StringBuilder html = new StringBuilder();
+        html.append("<b>You have version ")
+                .append(escapeHtml(version.isBlank() ? "(unknown)" : version))
+                .append(" of the NightVision CLI, but the plugin requires version ")
+                .append(escapeHtml(required))
+                .append(" to be fully operational.</b>");
+        if (resolvedPath != null && !resolvedPath.isBlank()) {
+            html.append("<br>Using ").append(escapeHtml(resolvedPath));
+        }
+        return wrapHtml(html.toString());
     }
 
     // pad is scaled, so the padding tracks the IDE's display scaling the way the

--- a/src/main/java/net/nightvision/plugin/auth/AuthenticationsCreateScreen.form
+++ b/src/main/java/net/nightvision/plugin/auth/AuthenticationsCreateScreen.form
@@ -206,7 +206,7 @@
                           </component>
                         </children>
                       </grid>
-                      <component id="ce711" class="javax.swing.JLabel" binding="errorMessage">
+                      <component id="ce711" class="com.intellij.ui.components.JBLabel" binding="errorMessage">
                         <constraints>
                           <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>

--- a/src/main/java/net/nightvision/plugin/auth/AuthenticationsCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/auth/AuthenticationsCreateScreen.java
@@ -13,6 +13,8 @@ import net.nightvision.plugin.services.AuthenticationService;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.util.ui.JBUI;
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 import java.awt.*;
 
@@ -26,7 +28,7 @@ public class AuthenticationsCreateScreen extends Screen {
     private JLabel helpMessageLabel;
     private JButton cancelButton;
     private JButton createButton;
-    private JLabel errorMessage;
+    private JBLabel errorMessage;
 
     public JPanel getAuthenticationsCreatePanel() {
         return authenticationsCreatePanel;
@@ -37,6 +39,7 @@ public class AuthenticationsCreateScreen extends Screen {
 
         authenticationsCreatePanel.setBorder(JBUI.Borders.empty(8));
 
+        makeSelectable(errorMessage);
         errorMessage.setVisible(false);
         backButton.addActionListener(e -> {
             mainWindowFactory.openAuthenticationsPage();

--- a/src/main/java/net/nightvision/plugin/auth/AuthenticationsCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/auth/AuthenticationsCreateScreen.java
@@ -77,24 +77,40 @@ public class AuthenticationsCreateScreen extends Screen {
             new Task.Backgroundable(project, "Create Authentication Playwright", false) {
                 @Override
                 public void run(@NotNull ProgressIndicator indicator) {
+                    // createPlaywrightAuth records an interactive browser login
+                    // and runs to a 200 second timeout, so the user can easily
+                    // navigate away before it returns. A late callback would
+                    // otherwise replace whatever screen they moved to.
                     try {
                         AuthenticationService.INSTANCE.createPlaywrightAuth(authName, authUrl, description);
 
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(authenticationsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openAuthenticationsPage();
                         });
                     } catch (CommandNotFoundException ex) {
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(authenticationsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openInstallCLIPage();
                         });
                     } catch (NotLoggedException ex) {
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(authenticationsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openLoginPage();
                         });
                         return;
                     } catch (Exception exception) {
                         ApplicationManager.getApplication().invokeLater(() -> {
-                            errorMessage.setText(exception.getMessage());
+                            if (!isMounted(authenticationsCreatePanel)) {
+                                return;
+                            }
+                            errorMessage.setText(asWrappedError(exception));
                             errorMessage.setVisible(true);
                         });
                     } finally {

--- a/src/main/java/net/nightvision/plugin/project/ProjectSelectionPanel.java
+++ b/src/main/java/net/nightvision/plugin/project/ProjectSelectionPanel.java
@@ -1,5 +1,7 @@
 package net.nightvision.plugin.project;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.ui.components.JBPanel;
 import net.nightvision.plugin.MainWindowFactory;
@@ -17,6 +19,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public class ProjectSelectionPanel extends JBPanel<ProjectSelectionPanel> {
+    private static final Logger LOG = Logger.getInstance(ProjectSelectionPanel.class);
+
     private final JLabel titleLabel;
     private final JComboBox<String> projectComboBox;
     // Callback (extra behavior) to execute when a project is selected.
@@ -65,25 +69,77 @@ public class ProjectSelectionPanel extends JBPanel<ProjectSelectionPanel> {
                 if (model.getSize() > 0 && model.getElementAt(0).isEmpty()) {
                     model.removeElementAt(0);
                 }
-                try {
-                    // Set the selected project as current.
-                    ProjectService.INSTANCE.setCurrentProjectName(selected);
-                    // Invoke the extra behavior callback if provided.
-                    if (onProjectSelected != null) {
-                        onProjectSelected.accept(selected);
-                    }
-                } catch (CommandNotFoundException ex) {
-                    mainWindowFactory.openInstallCLIPage();
-                } catch (NotLoggedException ex) {
-                    mainWindowFactory.openLoginPage();
-                } catch(Exception exception) {
-                    // TODO: handle better this exception, e.g. show message...
-                    // Exception here will happen if the project name is invalid or if some other error happened...
-                }
+                selectProject(mainWindowFactory, selected);
             }
         });
 
         add(projectComboBox, BorderLayout.CENTER);
+    }
+
+    /**
+     * Makes the selected project current, off the EDT.
+     *
+     * setCurrentProjectName runs "project set" and then "project show", and
+     * running those from the combo box's listener held the EDT for both:
+     * OSProcessHandler.waitFor asserts through checkEdtAndReadAction, so the
+     * IDE logged it at SEVERE and raised an "IDE error" the user reads as a
+     * crash, on top of freezing the UI (NV-4921).
+     *
+     * The combo is disabled for the duration. That is the only feedback the
+     * panel has room for, and it doubles as the guard against a second
+     * selection racing the first, which is why no request-ordering is needed
+     * here.
+     */
+    private void selectProject(MainWindowFactory mainWindowFactory, String selected) {
+        projectComboBox.setEnabled(false);
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            Throwable failure = null;
+            try {
+                ProjectService.INSTANCE.setCurrentProjectName(selected);
+            } catch (Throwable t) {
+                failure = t;
+            }
+            Throwable outcome = failure;
+            ApplicationManager.getApplication().invokeLater(
+                    () -> finishSelection(mainWindowFactory, selected, outcome));
+        });
+    }
+
+    /**
+     * Applies the outcome on the EDT.
+     *
+     * Deliberately not guarded on whether the panel is still mounted. The test
+     * Screen.isMounted makes would be wrong here: navigation replaces a
+     * screen's whole panel, and this panel stays a child of that discarded
+     * panel, so its parent is still set. Nor is a guard wanted. A callback only
+     * writes to combo boxes that are no longer displayed, and the two failures
+     * that navigate mean the CLI is missing or the login has expired, which
+     * every screen depends on wherever the user has got to.
+     */
+    private void finishSelection(MainWindowFactory mainWindowFactory, String selected, Throwable failure) {
+        projectComboBox.setEnabled(true);
+
+        if (failure == null) {
+            // Invoke the extra behavior callback if provided.
+            if (onProjectSelected != null) {
+                onProjectSelected.accept(selected);
+            }
+            return;
+        }
+        if (failure instanceof CommandNotFoundException) {
+            mainWindowFactory.openInstallCLIPage();
+            return;
+        }
+        if (failure instanceof NotLoggedException) {
+            mainWindowFactory.openLoginPage();
+            return;
+        }
+        // Anything else, such as a project name the CLI rejects, leaves the
+        // combo showing a project that is not current. The panel has no error
+        // label to put a reason in, and is shared by five screens, so it is
+        // logged rather than swallowed outright as it was before. Reverting
+        // the combo and reporting the reason is NV-4933.
+        LOG.warn("Could not switch to project '" + selected + "'", failure);
     }
 
     public static DefaultListCellRenderer getCommonRendererForCombobox() {

--- a/src/main/java/net/nightvision/plugin/project/ProjectsCreateScreen.form
+++ b/src/main/java/net/nightvision/plugin/project/ProjectsCreateScreen.form
@@ -98,7 +98,7 @@
               </component>
             </children>
           </grid>
-          <component id="a9fd2" class="javax.swing.JLabel" binding="errorMessage">
+          <component id="a9fd2" class="com.intellij.ui.components.JBLabel" binding="errorMessage">
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>

--- a/src/main/java/net/nightvision/plugin/project/ProjectsCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/project/ProjectsCreateScreen.java
@@ -60,19 +60,31 @@ public class ProjectsCreateScreen extends Screen {
                         ProjectService.INSTANCE.createProject(projectName);
 
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(projectsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openProjectsPage();
                         });
                     } catch (CommandNotFoundException ex) {
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(projectsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openInstallCLIPage();
                         });
                     } catch (NotLoggedException ex) {
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(projectsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openLoginPage();
                         });
                     } catch(Exception exception) {
                         ApplicationManager.getApplication().invokeLater(() -> {
-                            errorMessage.setText(exception.getMessage());
+                            if (!isMounted(projectsCreatePanel)) {
+                                return;
+                            }
+                            errorMessage.setText(asWrappedError(exception));
                             errorMessage.setVisible(true);
                         });
                     }

--- a/src/main/java/net/nightvision/plugin/project/ProjectsCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/project/ProjectsCreateScreen.java
@@ -12,6 +12,8 @@ import net.nightvision.plugin.services.ProjectService;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.util.ui.JBUI;
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 import java.awt.*;
 
@@ -21,7 +23,7 @@ public class ProjectsCreateScreen extends Screen {
     private JButton cancelButton;
     private JButton createButton;
     private JPanel projectsCreatePanel;
-    private JLabel errorMessage;
+    private JBLabel errorMessage;
 
     public JPanel getProjectsCreatePanel() {
         return projectsCreatePanel;
@@ -32,6 +34,7 @@ public class ProjectsCreateScreen extends Screen {
 
         projectsCreatePanel.setBorder(JBUI.Borders.empty(8));
 
+        makeSelectable(errorMessage);
         errorMessage.setVisible(false);
         backButton.addActionListener(e -> {
             mainWindowFactory.openProjectsPage();

--- a/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.form
+++ b/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.form
@@ -82,7 +82,7 @@
           <text value="Start Scan"/>
         </properties>
       </component>
-      <component id="17d74" class="javax.swing.JLabel" binding="scanStatusLabel">
+      <component id="17d74" class="com.intellij.ui.components.JBLabel" binding="scanStatusLabel">
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.form
+++ b/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.form
@@ -82,13 +82,12 @@
           <text value="Start Scan"/>
         </properties>
       </component>
-      <component id="17d74" class="javax.swing.JLabel" binding="errorMessageLabel">
+      <component id="17d74" class="javax.swing.JLabel" binding="scanStatusLabel">
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <foreground color="-65536"/>
-          <text value="&lt;Error message&gt;"/>
+          <text value="&lt;Scan status&gt;"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
@@ -14,6 +14,7 @@ import net.nightvision.plugin.services.ScanService;
 import net.nightvision.plugin.services.TargetService;
 
 import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 
@@ -32,7 +33,7 @@ public class ScansCreateScreen extends Screen {
     private JComboBox authenticationComboBox;
     private JButton startScanButton;
     private JLabel targetLabel;
-    private JLabel scanStatusLabel;
+    private JBLabel scanStatusLabel;
     private JPanel scansCreatePanel;
 
     private String targetType;
@@ -47,6 +48,7 @@ public class ScansCreateScreen extends Screen {
 
         scansCreatePanel.setBorder(JBUI.Borders.empty(8));
 
+        makeSelectable(scanStatusLabel);
         scanStatusLabel.setVisible(false);
 
         targetLabel.setText("Target (" + (targetType.equalsIgnoreCase("URL") ? "WEB" : "API") + ")");

--- a/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
@@ -153,10 +153,8 @@ public class ScansCreateScreen extends Screen {
         }
 
         private void showError(Throwable t) {
-            String message = t.getMessage();
             scanStatusLabel.setForeground(JBColor.RED);
-            scanStatusLabel.setText(asWrappedHtml(
-                    message == null || message.isBlank() ? t.toString() : message));
+            scanStatusLabel.setText(asWrappedError(t));
             scanStatusLabel.setVisible(true);
             startScanButton.setEnabled(true);
         }

--- a/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
@@ -13,11 +13,15 @@ import net.nightvision.plugin.services.AuthenticationService;
 import net.nightvision.plugin.services.ScanService;
 import net.nightvision.plugin.services.TargetService;
 
+import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+
 import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import static net.nightvision.plugin.project.ProjectSelectionPanel.getCommonRendererForCombobox;
 
@@ -28,7 +32,7 @@ public class ScansCreateScreen extends Screen {
     private JComboBox authenticationComboBox;
     private JButton startScanButton;
     private JLabel targetLabel;
-    private JLabel errorMessageLabel;
+    private JLabel scanStatusLabel;
     private JPanel scansCreatePanel;
 
     private String targetType;
@@ -43,7 +47,7 @@ public class ScansCreateScreen extends Screen {
 
         scansCreatePanel.setBorder(JBUI.Borders.empty(8));
 
-        errorMessageLabel.setVisible(false);
+        scanStatusLabel.setVisible(false);
 
         targetLabel.setText("Target (" + (targetType.equalsIgnoreCase("URL") ? "WEB" : "API") + ")");
 
@@ -61,21 +65,11 @@ public class ScansCreateScreen extends Screen {
 
         addButtonPadding(startScanButton, 6);
         startScanButton.addActionListener(e -> {
-            errorMessageLabel.setVisible(false);
-            errorMessageLabel.setText("");
+            showStatus("Starting scan, please wait...");
             startScanButton.setEnabled(false);
             var targetName = (String) targetComboBox.getSelectedItem();
             var authName = (String) authenticationComboBox.getSelectedItem();
-            try {
-                new StartScanWorker(targetName, authName).execute();
-                mainWindowFactory.openScansPage();
-            } catch (NotLoggedException ex) {
-                mainWindowFactory.openLoginPage();
-            } catch(Exception exception) {
-                errorMessageLabel.setText(exception.getMessage());
-                errorMessageLabel.setVisible(true);
-                startScanButton.setEnabled(true);
-            }
+            new StartScanWorker(targetName, authName).execute();
         });
         startScanButton.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
@@ -84,6 +78,21 @@ public class ScansCreateScreen extends Screen {
 
         loadTargetComboBox();
         loadAuthenticationComboBox();
+    }
+
+    /**
+     * Says the scan is being started. The screen stays put for as long as the
+     * startup deadline allows, which is up to two minutes, and a greyed-out
+     * button is the only other sign that anything is happening. Navigating to
+     * the scan list on submit used to be the acknowledgement that the click
+     * had registered; holding the page takes it away. The wording is the VS
+     * Code extension's, which prints the same sentence under its own Start
+     * Scan button.
+     */
+    private void showStatus(String message) {
+        scanStatusLabel.setForeground(UIUtil.getLabelForeground());
+        scanStatusLabel.setText(message);
+        scanStatusLabel.setVisible(true);
     }
 
     private class StartScanWorker extends SwingWorker<Void, Void> {
@@ -103,15 +112,52 @@ public class ScansCreateScreen extends Screen {
 
         @Override
         protected void done() {
+            // startScan waits on the CLI for as long as the startup deadline
+            // allows, which is long enough for the user to leave this screen.
+            // Acting on a detached instance would either replace whatever they
+            // navigated to or write the CLI's reason into a label that is no
+            // longer displayed, which is the stranded-message defect this
+            // routing exists to avoid (NV-4885). Mounted, not showing: a user
+            // who parks on the Terminal tool window for the two minutes this
+            // can take still wants the result when they come back.
+            if (!isMounted(scansCreatePanel)) {
+                return;
+            }
             try {
                 get();
-            } catch (CommandNotFoundException ex) {
-                mainWindowFactory.openInstallCLIPage();
-            } catch(Exception exception) {
-                errorMessageLabel.setText(exception.getMessage());
-                errorMessageLabel.setVisible(true);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                showError(ex);
+                return;
+            } catch (ExecutionException ex) {
+                // SwingWorker wraps whatever doInBackground threw, so the cause
+                // is what the routing below has to look at. Matching on the
+                // wrapper meant the CLI-not-found branch never ran and every
+                // failure surfaced as an ExecutionException toString.
+                Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+                if (cause instanceof CommandNotFoundException) {
+                    mainWindowFactory.openInstallCLIPage();
+                    return;
+                }
+                if (cause instanceof NotLoggedException) {
+                    mainWindowFactory.openLoginPage();
+                    return;
+                }
+                showError(cause);
+                return;
             }
+            // Only leave the page once the scan is known to have started.
+            // Navigating on submit stranded every failure message on a screen
+            // the user had already been taken off (NV-4827).
+            mainWindowFactory.openScansPage();
+        }
 
+        private void showError(Throwable t) {
+            String message = t.getMessage();
+            scanStatusLabel.setForeground(JBColor.RED);
+            scanStatusLabel.setText(asWrappedHtml(
+                    message == null || message.isBlank() ? t.toString() : message));
+            scanStatusLabel.setVisible(true);
             startScanButton.setEnabled(true);
         }
     }

--- a/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/scans/ScansCreateScreen.java
@@ -180,11 +180,14 @@ public class ScansCreateScreen extends Screen {
         authenticationComboBox.removeAllItems();
         List<AuthInfo> authInfos = AuthenticationService.INSTANCE.getAuthInfos();
         List<String> authNames = new ArrayList<>();
+        // First and selected by default, whatever the project holds. The field
+        // is optional, so "none" has to be reachable; offering it only when
+        // there was nothing else to choose meant every scan in a project with
+        // any authentication silently carried the first one in the list. The VS
+        // Code extension renders this same "-" entry on any optional dropdown.
+        authNames.add("");
         for (AuthInfo info : authInfos) {
             authNames.add(info.getName());
-        }
-        if (authNames.isEmpty()) {
-            authNames.add("");
         }
         authNames.forEach(name -> authenticationComboBox.addItem(name));
         authenticationComboBox.setSelectedIndex(0);

--- a/src/main/java/net/nightvision/plugin/scans/ScansScreen.java
+++ b/src/main/java/net/nightvision/plugin/scans/ScansScreen.java
@@ -26,6 +26,70 @@ import static net.nightvision.plugin.utils.TableUtils.addHoverEffects;
 public class ScansScreen extends Screen {
     private static final int PAGE_SIZE = 25;
 
+    /**
+     * Severity of each count in the Vulnerabilities column, in the order
+     * ScansTableModel.getValueAt builds them, with the color the VS Code
+     * extension and the web app both give it. The three orderings have to
+     * agree; changing one without the others mislabels every row.
+     *
+     * Medium is the one deliberate difference. The extension and the web app
+     * use a dark gold there, which sits too close to High: simulated, the two
+     * are about 14 dE apart under deuteranopia and 5 under tritanopia, close
+     * enough that a colorblind reader cannot reliably separate them. A brighter
+     * yellow reads the same to everyone else and opens that gap to 41 and 31,
+     * because it differs from High in lightness, which is the one channel every
+     * form of color vision deficiency leaves intact.
+     */
+    private static final String[] SEVERITY_NAMES = {
+            "Critical", "High", "Medium", "Low", "Informational"
+    };
+
+    private static final JBColor[] SEVERITY_COLORS = {
+            severityColor(0xDC2626), // Critical
+            severityColor(0xEA580C), // High
+            severityColor(0xFACC15), // Medium
+            severityColor(0x16A34A), // Low
+            severityColor(0x2563EB), // Informational
+    };
+
+    // One value for both themes: these are mid-tone, and a severity has to read
+    // as the same color wherever it is shown.
+    private static JBColor severityColor(int rgb) {
+        return new JBColor(new Color(rgb), new Color(rgb));
+    }
+
+    /**
+     * A filled circle in a severity's color. Drawn rather than loaded, so a
+     * severity's color lives beside its name instead of in five near-identical
+     * icon files.
+     */
+    private record SeverityDotIcon(Color color) implements Icon {
+        private static final int SIZE = 8;
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                        RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setColor(color);
+                g2.fillOval(x, y, getIconWidth(), getIconHeight());
+            } finally {
+                g2.dispose();
+            }
+        }
+
+        @Override
+        public int getIconWidth() {
+            return JBUI.scale(SIZE);
+        }
+
+        @Override
+        public int getIconHeight() {
+            return JBUI.scale(SIZE);
+        }
+    }
+
     private JTable scansTable;
     private JPanel scansPanel;
     private JButton backButton;
@@ -114,12 +178,25 @@ public class ScansScreen extends Screen {
                         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 5));
                         panel.add(label);
                     } else {
-                        for (int vulnerability : val) {
-                            Icon i = IconUtils.getIcon("/icons/dot.svg", .8f);
-                            JLabel label = new JLabel(String.valueOf(vulnerability), i, JLabel.LEFT);
+                        StringBuilder severities = new StringBuilder();
+                        for (int i = 0; i < val.length; i++) {
+                            JLabel label = new JLabel(String.valueOf(val[i]),
+                                    new SeverityDotIcon(SEVERITY_COLORS[i]), JLabel.LEFT);
                             label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 5));
                             panel.add(label);
+                            if (i > 0) {
+                                severities.append(", ");
+                            }
+                            severities.append(SEVERITY_NAMES[i]).append(' ').append(val[i]);
                         }
+                        // The dot's color is the only thing telling the five
+                        // counts apart, so name them for anyone who cannot use
+                        // it. The tip goes on the panel, not the labels: a
+                        // renderer is a rubber stamp that never joins the
+                        // component hierarchy, so JTable asks the component the
+                        // renderer handed back and never reaches a child of it.
+                        // Naming all five in one tip also beats five hovers.
+                        panel.setToolTipText(severities.toString());
                     }
 
 

--- a/src/main/java/net/nightvision/plugin/scans/ScansScreen.java
+++ b/src/main/java/net/nightvision/plugin/scans/ScansScreen.java
@@ -12,6 +12,8 @@ import net.nightvision.plugin.services.ScanService;
 import net.nightvision.plugin.utils.IconUtils;
 
 import com.intellij.util.ui.JBUI;
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 import java.awt.*;
 import java.util.List;
@@ -187,9 +189,10 @@ public class ScansScreen extends Screen {
 
     private void showLoadError() {
         loadingPanelParent.removeAll();
-        JLabel error = new JLabel(
+        JBLabel error = new JBLabel(
             "Could not load scans. Check your NightVision login and connection, then try again."
         );
+        makeSelectable(error);
         error.setForeground(JBColor.RED);
         loadingPanelParent.add(error);
         loadingPanelParent.revalidate();

--- a/src/main/java/net/nightvision/plugin/target/TargetsCreateScreen.form
+++ b/src/main/java/net/nightvision/plugin/target/TargetsCreateScreen.form
@@ -131,7 +131,7 @@
                           </component>
                         </children>
                       </grid>
-                      <component id="cf510" class="javax.swing.JLabel" binding="errorMessageWebTarget">
+                      <component id="cf510" class="com.intellij.ui.components.JBLabel" binding="errorMessageWebTarget">
                         <constraints>
                           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
@@ -215,7 +215,7 @@
                           </component>
                         </children>
                       </grid>
-                      <component id="dbd59" class="javax.swing.JLabel" binding="errorMessageApiTarget">
+                      <component id="dbd59" class="com.intellij.ui.components.JBLabel" binding="errorMessageApiTarget">
                         <constraints>
                           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>

--- a/src/main/java/net/nightvision/plugin/target/TargetsCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/target/TargetsCreateScreen.java
@@ -15,6 +15,8 @@ import net.nightvision.plugin.services.TargetService;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.util.ui.JBUI;
+import com.intellij.ui.components.JBLabel;
+
 import javax.swing.*;
 import java.awt.*;
 
@@ -26,12 +28,12 @@ public class TargetsCreateScreen extends Screen {
     private JTextField apiTargetUrlTextField;
     private JButton cancelApiTargetButton;
     private JButton createApiTargetButton;
-    private JLabel errorMessageApiTarget;
+    private JBLabel errorMessageApiTarget;
     private JTabbedPane apiTargetSpecTypeTabbedPane;
     private JTextField apiTargetSpecUrlTextField;
     private JButton uploadButton;
     private JLabel specFileName;
-    private JLabel errorMessageWebTarget;
+    private JBLabel errorMessageWebTarget;
     private JButton createWebTargetButton;
     private JButton cancelWebTargetButton;
     private JTextField webTargetNameTextField;
@@ -51,6 +53,7 @@ public class TargetsCreateScreen extends Screen {
 
         targetsCreatePanel.setBorder(JBUI.Borders.empty(8));
 
+        makeSelectable(errorMessageApiTarget, errorMessageWebTarget);
         errorMessageApiTarget.setVisible(false);
         errorMessageWebTarget.setVisible(false);
         specFileName.setVisible(false);

--- a/src/main/java/net/nightvision/plugin/target/TargetsCreateScreen.java
+++ b/src/main/java/net/nightvision/plugin/target/TargetsCreateScreen.java
@@ -95,21 +95,33 @@ public class TargetsCreateScreen extends Screen {
                         TargetService.INSTANCE.createWebTarget(targetName, targetURL);
 
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(targetsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openTargetsPage();
                         });
                     } catch (CommandNotFoundException ex) {
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(targetsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openInstallCLIPage();
                         });
                         return;
                     } catch (NotLoggedException ex) {
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(targetsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openLoginPage();
                         });
                         return;
                     } catch (Exception exception) {
                         ApplicationManager.getApplication().invokeLater(() -> {
-                            errorMessageWebTarget.setText(exception.getMessage());
+                            if (!isMounted(targetsCreatePanel)) {
+                                return;
+                            }
+                            errorMessageWebTarget.setText(asWrappedError(exception));
                             errorMessageWebTarget.setVisible(true);
                         });
                     } finally {
@@ -141,11 +153,17 @@ public class TargetsCreateScreen extends Screen {
                         TargetService.INSTANCE.createApiTarget(targetName, targetURL, swaggerPath, isSwaggerURL);
 
                         ApplicationManager.getApplication().invokeLater(() -> {
+                            if (!isMounted(targetsCreatePanel)) {
+                                return;
+                            }
                             mainWindowFactory.openTargetsPage();
                         });
                     } catch(Exception exception) {
                         ApplicationManager.getApplication().invokeLater(() -> {
-                            errorMessageApiTarget.setText(exception.getMessage());
+                            if (!isMounted(targetsCreatePanel)) {
+                                return;
+                            }
+                            errorMessageApiTarget.setText(asWrappedError(exception));
                             errorMessageApiTarget.setVisible(true);
                         });
                     } finally {

--- a/src/main/kotlin/net/nightvision/plugin/Constants.kt
+++ b/src/main/kotlin/net/nightvision/plugin/Constants.kt
@@ -12,7 +12,11 @@ class Constants {
         val API_URL: String = ApiUrlService.resolveApiUrl()
         val API_V1_URL: String = "$API_URL/$API_V1_SUFFIX"
 
-        const val APP_URL = "https://app.nightvision.net" // TODO: derive from API_URL if environments diverge
+        // Hardcoded while API_URL is resolved at runtime, so an IDE pointed at
+        // dev or test still opens production records here. NV-4934 covers
+        // deriving it, which needs an API-host to app-host mapping per
+        // environment rather than the single swap production allows.
+        const val APP_URL = "https://app.nightvision.net"
 
         const val CONTACT_EMAIL = "support@nightviz.ai"
 
@@ -28,14 +32,21 @@ class Constants {
         // replacing the literal with something that stays current.
         const val CLI_VERSION = "0.15.0"
 
+        // The trailing slash belongs to the API, not to every URL the plugin
+        // builds. The API is Django, which redirects a path that arrives
+        // without one, so these keep it.
         fun getApiUrlFor(suffix: String): URI {
-            return getUrlFor(API_V1_URL, suffix);
+            return getUrlFor(API_V1_URL, "$suffix/");
         }
 
         fun getApiUrlFor(suffix: String, params: Map<String, String> = emptyMap()): URI {
-            return getUrlFor(API_V1_URL, suffix, params);
+            return getUrlFor(API_V1_URL, "$suffix/", params);
         }
 
+        // The web app routes in the browser and does not answer these paths
+        // with a trailing slash: every "open in browser" link opened the app's
+        // home page rather than the record it named. The VS Code extension
+        // builds the same links without one.
         fun getAppUrlFor(suffix: String): URI {
             return getUrlFor(APP_URL, suffix);
         }
@@ -44,12 +55,12 @@ class Constants {
             return getUrlFor(APP_URL, suffix, params);
         }
 
-        fun getUrlFor(baseUrl: String, suffix: String): URI {
-            return URI.create("${baseUrl}/${suffix}/")
+        fun getUrlFor(baseUrl: String, path: String): URI {
+            return URI.create("${baseUrl}/${path}")
         }
 
-        fun getUrlFor(baseUrl: String, suffix: String, params: Map<String, String> = emptyMap()): URI {
-            var base = "${baseUrl}/${suffix}/"
+        fun getUrlFor(baseUrl: String, path: String, params: Map<String, String> = emptyMap()): URI {
+            val base = "${baseUrl}/${path}"
             val query = params.entries
                 .filter { it.value.isNotBlank() } // Only include non-empty values
                 .joinToString("&") { "${it.key}=${URLEncoder.encode(it.value, StandardCharsets.UTF_8)}" }

--- a/src/main/kotlin/net/nightvision/plugin/Constants.kt
+++ b/src/main/kotlin/net/nightvision/plugin/Constants.kt
@@ -16,7 +16,17 @@ class Constants {
 
         const val CONTACT_EMAIL = "support@nightviz.ai"
 
-        const val CLI_VERSION = "0.9.5"
+        // Oldest NightVision CLI the plugin will use without prompting for an
+        // update. Raise this when the plugin starts relying on newer CLI
+        // behaviour.
+        //
+        // 0.15.0 is the oldest version observed to complete a scan of a target
+        // that is not reachable from the internet: the QUIC relay transport and
+        // its yamux fallback arrived in 0.13.0, and older CLIs fail to bring up
+        // the relay tunnel (NV-4827). This was pinned at 0.9.5 long enough for
+        // that to reach a customer of the VS Code extension, so NV-4872 tracks
+        // replacing the literal with something that stays current.
+        const val CLI_VERSION = "0.15.0"
 
         fun getApiUrlFor(suffix: String): URI {
             return getUrlFor(API_V1_URL, suffix);

--- a/src/main/kotlin/net/nightvision/plugin/services/AuthenticationService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/AuthenticationService.kt
@@ -50,8 +50,9 @@ object AuthenticationService {
         val t = response.output
         val id = t.trim().takeIf { Regex("Id:").containsMatchIn(it) } ?: ""
         if (id.isBlank()) {
-            // TODO: Improve error message details
-            throw RuntimeException("Some error happened when creating your authentication.")
+            throw RuntimeException(
+                CommandRunnerService.missingRecordMessage("create the authentication", response.output, response.error)
+            )
         }
     }
 }

--- a/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
@@ -144,13 +144,19 @@ object CommandRunnerService {
         } else {
             val detail = failureDetail(output.stdout, output.stderr)
             LOG.warn("Command exited with ${output.exitCode}: ${command}. Detail: ${detail}")
+            // Worded for the person who clicked something, not for whoever
+            // reads the log: "the command" names nothing they did, and an exit
+            // code tells them nothing they can act on. Both are already in the
+            // LOG.warn above, which is where they are useful. This is also the
+            // wording missingRecordMessage uses for the failures that exit 0,
+            // so the two shapes of the same failure now read alike (NV-4827).
             if (output.isTimeout) {
-                throw RuntimeException("The command timed out")
+                throw RuntimeException("The NightVision CLI did not respond in time.")
             } else if (detail.isEmpty()) {
-                throw RuntimeException("The command failed (exit=${output.exitCode}) without reporting a reason.")
+                throw RuntimeException("The NightVision CLI failed without reporting a reason.")
             } else {
                 throw RuntimeException(
-                    "The command failed (exit=${output.exitCode}):\n${detail}"
+                    "The NightVision CLI reported an error:\n${detail}"
                 )
             }
         }

--- a/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
@@ -37,19 +37,97 @@ object CommandRunnerService {
 
     data class ExecutionResponse(val output: String, val error: String)
 
+    /**
+     * The phrase an expired login is reclassified on. Named here because two
+     * things depend on it: getSpecificRuntimeException matches it, and
+     * significantOutput must never drop the line carrying it.
+     */
+    const val EXPIRED_TOKEN_PHRASE = "token has expired. Please try to log in again"
+
+    /**
+     * How many lines of CLI output a message keeps. No screen in this plugin
+     * scrolls, so an unbounded detail runs off the tool window and takes the
+     * reason with it. The tail is what survives, because the CLI narrates
+     * forward and fails last.
+     */
+    private const val MAX_DETAIL_LINES = 12
+
+    /** The CLI's progress narration: timestamped, INFO level, one per step. */
+    private val PROGRESS_LINE = Regex("""^\[[^\]]*]\s+INFO\b""")
+
+    /**
+     * The part of the CLI's output worth putting in front of a user. A scan
+     * that fails prints a page of INFO lines covering DNS, TCP and TLS before
+     * saying what went wrong, which pushed the reason off the screen entirely.
+     * Fatal errors are printed plain rather than logged (NV-4827), so dropping
+     * the INFO narration keeps every reason while removing the noise.
+     *
+     * If nothing survives, the narration was all the CLI said, so its tail is
+     * kept rather than claiming the CLI gave no reason at all.
+     */
+    fun significantOutput(text: String): String {
+        val lines = text.trim().lines().map { it.trim() }.filter { it.isNotEmpty() }
+        val kept = lines.filter {
+            !PROGRESS_LINE.containsMatchIn(it) || EXPIRED_TOKEN_PHRASE in it
+        }
+        val chosen = if (kept.isNotEmpty()) kept else lines
+        return chosen.takeLast(MAX_DETAIL_LINES).joinToString("\n")
+    }
+
+    /**
+     * The CLI's own account of a failure, preferring stderr but falling back to
+     * stdout. Several CLI errors are printed to stdout rather than logged, so a
+     * message built from stderr alone is empty for exactly the failures a user
+     * most needs explained (NV-4827).
+     *
+     * The result reaches getSpecificRuntimeException, which reclassifies on the
+     * expired-token phrase, so the fallback could in principle widen that match
+     * to stdout. It does not, on either of the two caller shapes. runCommandSync
+     * hands the streams over separately, and the CLI emits that phrase only
+     * through its logger, which writes to stderr, so stderr is non-empty
+     * whenever the phrase is present and the fallback is not reached for it.
+     * The scan-startup caller has no separate stderr to hand over, since
+     * awaitStartup merges both streams into one buffer, so it passes that
+     * buffer as stdout and an empty stderr and the fallback runs every time.
+     * What it returns still carries the CLI's stderr, which is the only place
+     * the phrase can have come from, so the match is no wider there either.
+     */
+    fun failureDetail(stdout: String, stderr: String): String {
+        val err = stderr.trim()
+        if (err.isNotEmpty()) {
+            return significantOutput(err)
+        }
+        return significantOutput(stdout)
+    }
+
     private fun handleProcessResponse(
         command: String,
         output: ProcessOutput
     ): ExecutionResponse {
         if (!output.isTimeout && output.exitCode == 0) {
-            println("Success: ${output.stdout.trim()}")
+            // The command line only, deliberately, never output.stdout. This is
+            // the shared success path for every runCommandSync caller, and
+            // TokenService.createToken reads a live API token off it, so
+            // logging the output here would put credentials in idea.log. The
+            // println this replaced did exactly that on every login.
+            //
+            // The failure branch below logs failureDetail, which can fall back
+            // to stdout, and that is not the same exposure: the CLI prints a
+            // token as the very last statement of a successful run, after every
+            // failure path has already exited, so a run that failed has no
+            // token on stdout to fall back to. Note that plenty of other CLI
+            // errors do reach stdout, which is why the fallback exists at all.
+            LOG.debug("Command succeeded: ${command}")
         } else {
-            LOG.warn("Command exited with ${output.exitCode}: ${command}. Error: ${output.stderr.trim()}")
+            val detail = failureDetail(output.stdout, output.stderr)
+            LOG.warn("Command exited with ${output.exitCode}: ${command}. Detail: ${detail}")
             if (output.isTimeout) {
                 throw RuntimeException("The command timed out")
+            } else if (detail.isEmpty()) {
+                throw RuntimeException("The command failed (exit=${output.exitCode}) without reporting a reason.")
             } else {
                 throw RuntimeException(
-                    "The command failed (exit=${output.exitCode}):\n${output.stderr.trim()}"
+                    "The command failed (exit=${output.exitCode}):\n${detail}"
                 )
             }
         }
@@ -155,7 +233,7 @@ object CommandRunnerService {
     fun getSpecificRuntimeException(command: List<String>, e: Exception): Exception {
         val msg = e.message ?: ""
         when {
-            "token has expired. Please try to log in again" in msg ->
+            EXPIRED_TOKEN_PHRASE in msg ->
                 return NotLoggedException(command)
             else -> return e
         }

--- a/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
@@ -17,7 +17,10 @@ import net.nightvision.plugin.exceptions.NotLoggedException
 import net.nightvision.plugin.services.InstallCLIService.userCliVersion
 import java.io.File
 import java.io.IOException
+import java.io.InputStream
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.TimeUnit
 
 /**
@@ -191,6 +194,201 @@ object CommandRunnerService {
             throw e
         }
 
+    }
+
+    /**
+     * How often the startup wait re-checks whether the process is still alive.
+     */
+    private const val STARTUP_POLL_MS = 100L
+
+    /**
+     * Outcome of a command run under a startup deadline. Exactly one of
+     * [started], [exited] and [timedOut] is true.
+     *
+     * @param started the marker appeared, so the scan was accepted. The
+     *                process is normally still running; a marker seen as it
+     *                ended on its own counts too, since the acceptance stands
+     * @param exited  the process ended before the marker appeared
+     * @param timedOut the deadline passed with the process still running and no
+     *                 marker, so the process was destroyed
+     * @param output   everything the process printed, both streams interleaved
+     */
+    data class StartupOutcome(
+        val started: Boolean,
+        val exited: Boolean,
+        val timedOut: Boolean,
+        val output: String
+    )
+
+    /**
+     * Runs [command] and waits only until [marker] appears in its output rather
+     * than for the process to finish, then leaves it running.
+     *
+     * A long-running command cannot be run through [runCommandSync]: that waits
+     * for the whole process and destroys it at the timeout, so a scan lasting
+     * longer than the timeout was killed mid-run. Killing the CLI sends SIGTERM,
+     * which it handles by cancelling the scan server-side, so the cap did not
+     * merely time out the wait, it cancelled a scan that was running perfectly
+     * well. Bounding startup instead means the deadline can only ever fire while
+     * there is no scan to cancel (NV-4827).
+     *
+     * Both streams are drained on background threads for the life of the
+     * process, so a caller that returns early cannot leave the child blocked on
+     * a full pipe.
+     */
+    fun runCommandUntilStarted(
+        vararg command: String,
+        marker: Regex,
+        startupTimeoutMs: Long,
+        workingDirectory: String = ""
+    ): StartupOutcome {
+        var cmd = GeneralCommandLine(*command)
+            .withEnvironment("PATH", getPathForGeneralCommandLine())
+        if (workingDirectory.isNotEmpty()) {
+            cmd = cmd.withWorkDirectory(workingDirectory)
+        }
+        return awaitStartup(cmd, marker, startupTimeoutMs, command.toList())
+    }
+
+    /**
+     * The process half of [runCommandUntilStarted], split out so it can be
+     * exercised against real processes without a live platform supplying the
+     * login-shell PATH.
+     */
+    fun awaitStartup(
+        commandLine: GeneralCommandLine,
+        marker: Regex,
+        startupTimeoutMs: Long,
+        command: List<String>
+    ): StartupOutcome {
+        try {
+            val process = commandLine.createProcess()
+            val buffer = StringBuilder()
+            val sawMarker = CountDownLatch(1)
+            // Cleared once the outcome has been reported. The streams still have
+            // to be drained for the life of the process, but past that point the
+            // buffer is nobody's: a scan runs for as long as it takes, and
+            // appending its whole output would grow the IDE's heap for nothing.
+            val capturing = AtomicBoolean(true)
+
+            fun pump(stream: InputStream): Thread {
+                val t = Thread {
+                    try {
+                        stream.bufferedReader().forEachLine { line ->
+                            // Checked inside the lock, not before it: outside,
+                            // a line could pass the check and then lose the
+                            // race to stopCapturing, dropping the last
+                            // diagnostic the process managed to print.
+                            synchronized(buffer) {
+                                if (capturing.get()) {
+                                    buffer.append(line).append('\n')
+                                }
+                            }
+                            if (marker.containsMatchIn(line)) {
+                                sawMarker.countDown()
+                            }
+                        }
+                    } catch (e: IOException) {
+                        LOG.debug("Output stream closed for ${command.firstOrNull()}", e)
+                    }
+                }
+                t.isDaemon = true
+                t.start()
+                return t
+            }
+
+            val pumps = listOf(pump(process.inputStream), pump(process.errorStream))
+
+            val deadline = System.currentTimeMillis() + startupTimeoutMs
+            var started = false
+            while (true) {
+                if (sawMarker.await(STARTUP_POLL_MS, TimeUnit.MILLISECONDS)) {
+                    started = true
+                    break
+                }
+                if (!process.isAlive) {
+                    break
+                }
+                if (System.currentTimeMillis() >= deadline) {
+                    break
+                }
+            }
+
+            if (started) {
+                // Deliberately left running: the scan is under way and the
+                // process must see it through.
+                return StartupOutcome(started = true, exited = false, timedOut = false,
+                    output = stopCapturing(capturing, buffer))
+            }
+
+            // The marker can land between the loop's last check and here, and on
+            // the timeout path the process is still healthy: destroying it first
+            // would cancel the very scan the marker just announced, and report
+            // that as a timeout. Testing before the destroy keeps the deadline
+            // from firing on a scan that started.
+            if (sawMarker.count == 0L) {
+                return StartupOutcome(started = true, exited = false, timedOut = false,
+                    output = stopCapturing(capturing, buffer))
+            }
+
+            val alive = process.isAlive
+            if (alive) {
+                stopProcess(process)
+            }
+            // Let the pumps finish so the reported output is not cut short.
+            pumps.forEach { it.join(STARTUP_POLL_MS * 5) }
+            // A marker arriving during the drain still counts, but only where the
+            // process ended on its own: once it has been destroyed the scan is
+            // gone whatever the marker said.
+            if (sawMarker.count == 0L && !alive) {
+                return StartupOutcome(started = true, exited = false, timedOut = false,
+                    output = stopCapturing(capturing, buffer))
+            }
+            return StartupOutcome(
+                started = false,
+                exited = !alive,
+                timedOut = alive,
+                output = stopCapturing(capturing, buffer)
+            )
+        } catch (e: IOException) {
+            throw getSpecificException(command, e)
+        } catch (e: ProcessNotCreatedException) {
+            throw getSpecificException(command, e)
+        }
+    }
+
+    /**
+     * How long a process gets to act on the SIGTERM before it is killed
+     * outright.
+     */
+    private const val TERMINATE_GRACE_MS = 2_000L
+
+    /**
+     * Ends [process], escalating if it does not go. destroy() is a SIGTERM, and
+     * a CLI wedged badly enough to miss its startup deadline is exactly the one
+     * that may not act on it; without the escalation the deadline would report
+     * a scan as stopped while the process ran on.
+     */
+    private fun stopProcess(process: Process) {
+        process.destroy()
+        if (!process.waitFor(TERMINATE_GRACE_MS, TimeUnit.MILLISECONDS)) {
+            LOG.warn("CLI did not exit on terminate within ${TERMINATE_GRACE_MS}ms; killing it")
+            process.destroyForcibly()
+        }
+    }
+
+    /**
+     * Final read of the output, after which the pumps stop appending. Called on
+     * every exit from [awaitStartup], since nothing reads the buffer again.
+     */
+    private fun stopCapturing(capturing: AtomicBoolean, buffer: StringBuilder): String {
+        // Clearing the flag and reading the buffer happen together, so a pump
+        // holding the lock has already appended and no line is lost between
+        // the two.
+        return synchronized(buffer) {
+            capturing.set(false)
+            buffer.toString().trim()
+        }
     }
 
     @Throws(ProcessNotCreatedException::class)

--- a/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
@@ -197,6 +197,54 @@ object CommandRunnerService {
     }
 
     /**
+     * Names a nightvision executable can take on Windows, in the relative order
+     * PATHEXT gives them by default, so that where a directory holds more than
+     * one the resolved path names the same file a shell would run. Getting the
+     * order wrong would misreport exactly the ambiguous case the NV-4873
+     * tooltip exists to settle. PATHEXT ranks .COM ahead of all of these, but
+     * nothing ships nightvision in the DOS .com format, so it is not looked up.
+     */
+    private val WINDOWS_CLI_NAMES = listOf("nightvision.exe", "nightvision.bat", "nightvision.cmd")
+
+    /**
+     * Absolute path of the nightvision the plugin will actually run, or null if
+     * none is on the search path.
+     *
+     * getPathForGeneralCommandLine prepends the plugin's own install directory,
+     * so a copy it installed once takes precedence over any newer CLI the user
+     * has installed since. Nothing surfaced which binary was in use, leaving a
+     * user running a current CLI in their terminal no way to see that the
+     * plugin was using an old one (NV-4873).
+     */
+    fun resolveCliPath(): String? = resolveCliPathIn(getPathForGeneralCommandLine())
+
+    /**
+     * First nightvision executable on [searchPath]. Split from the environment
+     * lookup so it can be unit tested against a constructed path.
+     */
+    fun resolveCliPathIn(
+        searchPath: String,
+        windows: Boolean = System.getProperty("os.name").startsWith("Windows"),
+        isExecutable: (File) -> Boolean = { it.isFile && it.canExecute() }
+    ): String? {
+        // On Windows canExecute() is true for any readable file, so the name
+        // carries the executability and the extension list is what matters.
+        val names = if (windows) WINDOWS_CLI_NAMES else listOf(NIGHTVISION)
+        for (dir in searchPath.split(File.pathSeparator)) {
+            if (dir.isBlank()) {
+                continue
+            }
+            for (name in names) {
+                val candidate = File(dir, name)
+                if (isExecutable(candidate)) {
+                    return candidate.path
+                }
+            }
+        }
+        return null
+    }
+
+    /**
      * How often the startup wait re-checks whether the process is still alive.
      */
     private const val STARTUP_POLL_MS = 100L

--- a/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/CommandRunnerService.kt
@@ -103,6 +103,26 @@ object CommandRunnerService {
         return significantOutput(stdout)
     }
 
+    /**
+     * Message for a CLI run that ended without the record the caller needed,
+     * where [what] names the action in the infinitive ("create the project").
+     * The CLI's own output carries the reason, so it is reported rather than
+     * replaced with a generic failure (NV-4827).
+     *
+     * The runCommandSync callers only arrive here after a zero exit, since
+     * handleProcessResponse throws on anything else, but the scan-startup
+     * caller arrives on any exit that precedes the marker. Nothing below reads
+     * the exit status, so the two are formatted alike; do not add a branch that
+     * assumes a clean exit.
+     */
+    fun missingRecordMessage(what: String, stdout: String, stderr: String): String {
+        val detail = failureDetail(stdout, stderr)
+        if (detail.isEmpty()) {
+            return "The NightVision CLI did not $what, and reported no reason."
+        }
+        return "The NightVision CLI did not $what:\n$detail"
+    }
+
     private fun handleProcessResponse(
         command: String,
         output: ProcessOutput

--- a/src/main/kotlin/net/nightvision/plugin/services/ProjectService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/ProjectService.kt
@@ -47,8 +47,9 @@ object ProjectService {
         val t = response.output
         val id = t.trim().takeIf { Regex("Id:").containsMatchIn(it) } ?: ""
         if (id.isBlank()) {
-            // TODO: Improve error message details
-            throw RuntimeException("Some error happened when creating your project.")
+            throw RuntimeException(
+                CommandRunnerService.missingRecordMessage("create the project", response.output, response.error)
+            )
         }
     }
 

--- a/src/main/kotlin/net/nightvision/plugin/services/ProjectService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/ProjectService.kt
@@ -68,11 +68,11 @@ object ProjectService {
         val t = response.output
         val regexProjName = Regex("""(?m)^Name:\s*(.+)$""")
         val matchProjName = regexProjName.find(t)
-        currentProjectName = matchProjName?.groupValues?.get(1) ?: ""
+        currentProjectName = matchProjName?.groupValues?.get(1)?.trim() ?: ""
 
         val regexProjId = Regex("""(?m)^Id:\s*(.+)$""")
         val matchProjId = regexProjId.find(t)
-        currentProjectId = matchProjId?.groupValues?.get(1) ?: ""
+        currentProjectId = matchProjId?.groupValues?.get(1)?.trim() ?: ""
 
         return currentProjectName
     }
@@ -83,14 +83,18 @@ object ProjectService {
         }
         var cmd = ArrayList<String>(listOf(NIGHTVISION, "project", "set", projectName))
 
-        val response = CommandRunnerService.runCommandSync(*cmd.toTypedArray())
-        val t = response.output
-        val success = Regex("Current project changed").containsMatchIn(t.trim())
-        if (success) {
-            fetchCurrentProjectName()
-            return
+        CommandRunnerService.runCommandSync(*cmd.toTypedArray())
+
+        // Confirmed by reading the project back, not by matching what the CLI
+        // said. It answers "Current project changed to X." when it switches but
+        // "X is already the current project" when X was already current, and
+        // matching only the first reported selecting the current project as a
+        // failure. runCommandSync has already thrown if the CLI rejected the
+        // name, so what is left to check is the outcome rather than the wording.
+        val actual = fetchCurrentProjectName()
+        if (actual != projectName) {
+            throw RuntimeException("Unable to set project to '${projectName}'")
         }
-        throw RuntimeException("Unable to set project to '${projectName}'")
     }
 
 }

--- a/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
@@ -19,6 +19,13 @@ object ScanService {
      */
     val SCAN_STARTED = Regex("INFO Scan Details")
 
+    /**
+     * How long the CLI is given to report a scan before the attempt is judged
+     * to have hung. Only startup is bounded; once the scan is under way the CLI
+     * runs for as long as the scan takes.
+     */
+    const val SCAN_START_TIMEOUT_MS = 120_000L
+
     val httpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(15))
         .build()
@@ -53,10 +60,50 @@ object ScanService {
             cmd.add(authenticationName)
         }
 
-        val response = CommandRunnerService.runCommandSync(*cmd.toTypedArray())
-        if (!SCAN_STARTED.containsMatchIn(response.output)) {
-            throw RuntimeException(noScanStartedMessage(response.output, response.error))
+        val outcome = CommandRunnerService.runCommandUntilStarted(
+            *cmd.toTypedArray(),
+            marker = SCAN_STARTED,
+            startupTimeoutMs = SCAN_START_TIMEOUT_MS
+        )
+        if (outcome.started) {
+            return
         }
+        val message = if (outcome.timedOut) {
+            startupTimedOutMessage(SCAN_START_TIMEOUT_MS, outcome.output)
+        } else {
+            noScanStartedMessage(outcome.output, "")
+        }
+        // Routed through the same mapping runCommandSync uses, so an expired
+        // login still sends the user to the login page rather than surfacing
+        // as a bare failure.
+        throw CommandRunnerService.getSpecificRuntimeException(
+            cmd, RuntimeException(message)
+        )
+    }
+
+    /**
+     * Message for a CLI that never reported a scan and had to be stopped. The
+     * relay is named because it is the usual cause: a target that is not
+     * reachable from the internet is scanned through it, and an older CLI can
+     * obtain a relay id and then never bring the tunnel up (NV-4827).
+     *
+     * What the CLI printed before it hung is appended rather than dropped. It
+     * carries the real reason whenever the relay is not the cause, and the
+     * caller routes an expired login to the login page by matching the message
+     * text, which cannot match words that were never included. It goes through
+     * significantOutput first, so the progress narration a hung scan produces
+     * most of does not push that reason off the screen.
+     */
+    fun startupTimedOutMessage(timeoutMs: Long, output: String): String {
+        val seconds = Math.round(timeoutMs / 1000.0)
+        val message = "The NightVision CLI did not start a scan within $seconds seconds and was " +
+            "stopped. The most common cause is a failed connection to the NightVision " +
+            "relay, which is required for targets that are not reachable from the internet."
+        val detail = CommandRunnerService.significantOutput(output)
+        if (detail.isEmpty()) {
+            return message
+        }
+        return "$message\n$detail"
     }
 
     /**

--- a/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
@@ -49,16 +49,27 @@ object ScanService {
         return gson.fromJson(response.body(), type)
     }
 
+    /**
+     * The CLI invocation for a scan. The authentication flag is omitted for a
+     * blank name as well as a null one: the create-scan combo box carries an
+     * empty entry when the project has no authentications, and passing that
+     * through sent the CLI an --auth with an empty value.
+     */
+    fun buildScanCommand(targetName: String, authenticationName: String?): List<String> {
+        val cmd = ArrayList<String>(listOf(NIGHTVISION, "scan", targetName))
+        if (!authenticationName.isNullOrBlank()) {
+            cmd.add("--auth")
+            cmd.add(authenticationName)
+        }
+        return cmd
+    }
+
     fun startScan(targetName: String, authenticationName: String?) {
         if (targetName.isBlank()) {
             throw IllegalArgumentException("Target name can't be empty.");
         }
 
-        var cmd = ArrayList<String>(listOf(NIGHTVISION, "scan", targetName))
-        if (authenticationName != null) {
-            cmd.add("--auth")
-            cmd.add(authenticationName)
-        }
+        val cmd = buildScanCommand(targetName, authenticationName)
 
         val outcome = CommandRunnerService.runCommandUntilStarted(
             *cmd.toTypedArray(),

--- a/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
@@ -13,6 +13,12 @@ import java.net.http.HttpResponse
 import java.util.concurrent.TimeUnit
 
 object ScanService {
+    /**
+     * The CLI logs this record as soon as the backend has accepted the scan, so
+     * its presence is what distinguishes a started scan from a failed attempt.
+     */
+    val SCAN_STARTED = Regex("INFO Scan Details")
+
     val httpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(15))
         .build()
@@ -48,11 +54,22 @@ object ScanService {
         }
 
         val response = CommandRunnerService.runCommandSync(*cmd.toTypedArray())
-        val t = response.output
-        val id = t.trim().takeIf { Regex("INFO Scan Details").containsMatchIn(it) } ?: ""
-        if (id.isBlank()) {
-            // TODO: Improve error message details
-            throw RuntimeException("Some error happened when creating your scan.")
+        if (!SCAN_STARTED.containsMatchIn(response.output)) {
+            throw RuntimeException(noScanStartedMessage(response.output, response.error))
         }
+    }
+
+    /**
+     * Message for a CLI run that ended without ever logging its scan details.
+     * The CLI's own output carries the reason (target not in the project, relay
+     * setup failure, a rejected start-scan request), so it is reported rather
+     * than replaced with a generic failure (NV-4827).
+     */
+    fun noScanStartedMessage(stdout: String, stderr: String): String {
+        val detail = CommandRunnerService.failureDetail(stdout, stderr)
+        if (detail.isEmpty()) {
+            return "The NightVision CLI exited without starting a scan and without reporting a reason."
+        }
+        return "The NightVision CLI exited without starting a scan:\n${detail}"
     }
 }

--- a/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/ScanService.kt
@@ -123,11 +123,6 @@ object ScanService {
      * setup failure, a rejected start-scan request), so it is reported rather
      * than replaced with a generic failure (NV-4827).
      */
-    fun noScanStartedMessage(stdout: String, stderr: String): String {
-        val detail = CommandRunnerService.failureDetail(stdout, stderr)
-        if (detail.isEmpty()) {
-            return "The NightVision CLI exited without starting a scan and without reporting a reason."
-        }
-        return "The NightVision CLI exited without starting a scan:\n${detail}"
-    }
+    fun noScanStartedMessage(stdout: String, stderr: String): String =
+        CommandRunnerService.missingRecordMessage("start a scan", stdout, stderr)
 }

--- a/src/main/kotlin/net/nightvision/plugin/services/TargetService.kt
+++ b/src/main/kotlin/net/nightvision/plugin/services/TargetService.kt
@@ -99,8 +99,9 @@ object TargetService {
         val t = response.output
         val id = t.trim().takeIf { Regex("Id:").containsMatchIn(it) } ?: ""
         if (id.isBlank()) {
-            // TODO: Improve error message details
-            throw RuntimeException("Some error happened when creating your target.")
+            throw RuntimeException(
+                CommandRunnerService.missingRecordMessage("create the target", response.output, response.error)
+            )
         }
     }
 }

--- a/src/main/resources/icons/dot.svg
+++ b/src/main/resources/icons/dot.svg
@@ -1,4 +1,0 @@
-<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="5" cy="5" r="5" fill="white" />
-    <circle cx="4" cy="4" r="4" fill="black" transform="translate(1, 1)"/>
-</svg>

--- a/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerServiceTest.kt
@@ -81,4 +81,66 @@ class CommandRunnerServiceTest {
         val result = CommandRunnerService.getSpecificException(testCommand, ex)
         assertTrue(result is PermissionDeniedException)
     }
+
+    @Test
+    fun `failureDetail prefers stderr`() {
+        assertEquals("boom", CommandRunnerService.failureDetail("chatter", "boom"))
+    }
+
+    @Test
+    fun `failureDetail falls back to stdout when stderr is empty`() {
+        // Several CLI errors are printed to stdout rather than logged, so a
+        // detail taken from stderr alone is empty for exactly those failures.
+        assertEquals("boom", CommandRunnerService.failureDetail("boom", ""))
+    }
+
+    @Test
+    fun `failureDetail is empty when the process said nothing`() {
+        assertEquals("", CommandRunnerService.failureDetail("  ", "\n"))
+    }
+
+    @Test
+    fun `significantOutput drops the CLI progress narration`() {
+        // A failed scan narrates DNS, TCP and TLS before it says what went
+        // wrong, and no screen in the plugin scrolls, so the narration pushed
+        // the reason out of the tool window.
+        val output = """
+            [2026-08-21 08:18:17] INFO Launching NightVision CLI
+            [2026-08-21 08:18:18] INFO Target connectivity test: starting DNS query
+            [2026-08-21 08:18:18] INFO Target connectivity test: TLS handshake done
+            target public-javaspringvulny does not exist
+        """.trimIndent()
+        assertEquals(
+            "target public-javaspringvulny does not exist",
+            CommandRunnerService.significantOutput(output)
+        )
+    }
+
+    @Test
+    fun `significantOutput keeps an expired login even when logged at INFO`() {
+        // getSpecificRuntimeException reclassifies on this phrase, so dropping
+        // the line carrying it would strand the user on a generic error
+        // instead of the login page.
+        val output = "[2026-08-21 08:18:17] INFO Launching NightVision CLI\n" +
+            "[2026-08-21 08:18:18] INFO It seems your login authentication " +
+            "token has expired. Please try to log in again."
+        val detail = CommandRunnerService.significantOutput(output)
+        assertTrue(CommandRunnerService.EXPIRED_TOKEN_PHRASE in detail)
+    }
+
+    @Test
+    fun `significantOutput keeps the tail when everything is narration`() {
+        val output = (1..30).joinToString("\n") { "[2026-08-21 08:18:17] INFO step $it" }
+        val detail = CommandRunnerService.significantOutput(output)
+        assertTrue(detail.endsWith("INFO step 30"))
+        assertEquals(12, detail.lines().size)
+    }
+
+    @Test
+    fun `significantOutput bounds a reason that runs long`() {
+        val output = (1..40).joinToString("\n") { "reason line $it" }
+        val detail = CommandRunnerService.significantOutput(output)
+        assertEquals(12, detail.lines().size)
+        assertTrue(detail.endsWith("reason line 40"))
+    }
 }

--- a/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerServiceTest.kt
@@ -201,4 +201,17 @@ class CommandRunnerServiceTest {
             "${sep}${sep}/only", windows = false, isExecutable = { it.path == "/only/nightvision" })
         assertEquals("/only/nightvision", found)
     }
+
+    @Test
+    fun `missingRecordMessage reports the CLI detail`() {
+        val m = CommandRunnerService.missingRecordMessage("create the project", "", "name already taken")
+        assertTrue(m.contains("create the project"))
+        assertTrue(m.contains("name already taken"))
+    }
+
+    @Test
+    fun `missingRecordMessage stands alone when the CLI said nothing`() {
+        val m = CommandRunnerService.missingRecordMessage("create the target", "", "")
+        assertTrue(m.contains("reported no reason"))
+    }
 }

--- a/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerServiceTest.kt
@@ -143,4 +143,62 @@ class CommandRunnerServiceTest {
         assertEquals(12, detail.lines().size)
         assertTrue(detail.endsWith("reason line 40"))
     }
+
+    @Test
+    fun `resolveCliPathIn returns the first match on the search path`() {
+        val sep = File.pathSeparator
+        val path = "/first${sep}/second"
+        val found = CommandRunnerService.resolveCliPathIn(
+            path, windows = false, isExecutable = { it.path == "/second/nightvision" })
+        assertEquals("/second/nightvision", found)
+    }
+
+    @Test
+    fun `resolveCliPathIn prefers the earlier directory`() {
+        val sep = File.pathSeparator
+        // The plugin prepends its own install dir, which is why a copy it
+        // installed once shadows a newer CLI installed later (NV-4873).
+        val path = "$cliDir${sep}/usr/local/bin"
+        val found = CommandRunnerService.resolveCliPathIn(
+            path, windows = false, isExecutable = { true })
+        assertEquals("$cliDir/nightvision", found)
+    }
+
+    @Test
+    fun `resolveCliPathIn looks for the exe name on Windows`() {
+        val found = CommandRunnerService.resolveCliPathIn(
+            "C:\\tools", windows = true,
+            isExecutable = { it.name == "nightvision.exe" })
+        assertTrue("got $found", found!!.endsWith("nightvision.exe"))
+    }
+
+    @Test
+    fun `resolveCliPathIn falls back to cmd and bat on Windows`() {
+        val found = CommandRunnerService.resolveCliPathIn(
+            "C:\\tools", windows = true,
+            isExecutable = { it.name == "nightvision.cmd" })
+        assertTrue("got $found", found!!.endsWith("nightvision.cmd"))
+    }
+
+    @Test
+    fun `resolveCliPathIn prefers bat over cmd, as PATHEXT does`() {
+        val found = CommandRunnerService.resolveCliPathIn(
+            "C:\\tools", windows = true,
+            isExecutable = { it.name == "nightvision.cmd" || it.name == "nightvision.bat" })
+        assertTrue("got $found", found!!.endsWith("nightvision.bat"))
+    }
+
+    @Test
+    fun `resolveCliPathIn returns null when nothing is on the path`() {
+        assertNull(CommandRunnerService.resolveCliPathIn(
+            "/nowhere", windows = false, isExecutable = { false }))
+    }
+
+    @Test
+    fun `resolveCliPathIn skips empty path entries`() {
+        val sep = File.pathSeparator
+        val found = CommandRunnerService.resolveCliPathIn(
+            "${sep}${sep}/only", windows = false, isExecutable = { it.path == "/only/nightvision" })
+        assertEquals("/only/nightvision", found)
+    }
 }

--- a/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerStartupTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/CommandRunnerStartupTest.kt
@@ -1,0 +1,83 @@
+package net.nightvision.plugin.services
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Exercises the startup deadline against real processes. The question is
+ * whether the deadline fires against a live child and leaves a started one
+ * alone, which a stubbed process handler cannot answer.
+ */
+class CommandRunnerStartupTest {
+
+    private val marker = Regex("INFO Scan Details")
+    private val isWindows = System.getProperty("os.name").startsWith("Windows")
+
+    /** A shell command, named per platform rather than skipped on Windows. */
+    private fun shell(unix: String, windows: String): GeneralCommandLine =
+        if (isWindows) GeneralCommandLine("cmd", "/c", windows)
+        else GeneralCommandLine("sh", "-c", unix)
+
+    private fun run(cmd: GeneralCommandLine, timeoutMs: Long) =
+        CommandRunnerService.awaitStartup(cmd, marker, timeoutMs, listOf("test"))
+
+    @Test
+    fun `returns as soon as the marker appears and leaves the process running`() {
+        val cmd = shell(
+            "echo 'INFO Scan Details'; sleep 30",
+            "echo INFO Scan Details& timeout /t 30 /nobreak > NUL"
+        )
+        val began = System.currentTimeMillis()
+        val outcome = run(cmd, 30_000)
+        val elapsed = System.currentTimeMillis() - began
+
+        assertTrue("expected started", outcome.started)
+        assertFalse(outcome.timedOut)
+        // It must not have waited for the process to finish; the point of the
+        // change is that a scan outlives the startup wait.
+        assertTrue("returned after ${elapsed}ms, so it waited for exit", elapsed < 20_000)
+    }
+
+    @Test
+    fun `reports a process that exits before the marker`() {
+        val outcome = run(shell("echo boom; exit 3", "echo boom& exit 3"), 10_000)
+
+        assertFalse(outcome.started)
+        assertTrue("expected exited", outcome.exited)
+        assertFalse(outcome.timedOut)
+        assertTrue("output was '${outcome.output}'", outcome.output.contains("boom"))
+    }
+
+    @Test
+    fun `captures output the process wrote to stderr`() {
+        val outcome = run(shell("echo boom 1>&2; exit 1", "echo boom 1>&2& exit 1"), 10_000)
+
+        assertFalse(outcome.started)
+        assertTrue("output was '${outcome.output}'", outcome.output.contains("boom"))
+    }
+
+    @Test
+    fun `stops a process that never reports a scan`() {
+        val began = System.currentTimeMillis()
+        val outcome = run(shell("sleep 30", "timeout /t 30 /nobreak > NUL"), 1_000)
+        val elapsed = System.currentTimeMillis() - began
+
+        assertFalse(outcome.started)
+        assertTrue("expected timedOut", outcome.timedOut)
+        assertFalse(outcome.exited)
+        assertTrue("waited ${elapsed}ms for a 1s deadline", elapsed < 15_000)
+    }
+
+    @Test
+    fun `a marker on a later line still counts as started`() {
+        val outcome = run(
+            shell(
+                "echo warming up; echo 'INFO Scan Details'; sleep 30",
+                "echo warming up& echo INFO Scan Details& timeout /t 30 /nobreak > NUL"
+            ),
+            30_000
+        )
+        assertTrue(outcome.started)
+    }
+}

--- a/src/test/kotlin/net/nightvision/plugin/services/InstallCLIServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/InstallCLIServiceTest.kt
@@ -1,0 +1,39 @@
+package net.nightvision.plugin.services
+
+import net.nightvision.plugin.Constants
+import org.junit.Assert.*
+import org.junit.Test
+
+class InstallCLIServiceTest {
+
+    @Test
+    fun `the version floor is the one that can scan through the relay`() {
+        assertEquals("0.15.0", Constants.CLI_VERSION)
+    }
+
+    @Test
+    fun `a CLI below the floor is offered an update`() {
+        // 0.9.15 is the version a customer ran under the VS Code extension
+        // while the floor was 0.9.5, so it was never prompted (NV-4872).
+        assertTrue(InstallCLIService.shouldUpdateCLI("0.9.15"))
+        assertTrue(InstallCLIService.shouldUpdateCLI("0.14.9"))
+    }
+
+    @Test
+    fun `a CLI at or above the floor is left alone`() {
+        assertFalse(InstallCLIService.shouldUpdateCLI("0.15.0"))
+        assertFalse(InstallCLIService.shouldUpdateCLI("0.16.2"))
+        assertFalse(InstallCLIService.shouldUpdateCLI("1.0.0"))
+    }
+
+    @Test
+    fun `an unknown version is not prompted`() {
+        assertFalse(InstallCLIService.shouldUpdateCLI(""))
+    }
+
+    @Test
+    fun `version comparison orders by component, not lexically`() {
+        // "0.9.15" sorts above "0.15.0" as text; the comparison must not.
+        assertTrue(InstallCLIService.shouldUpdateCLI("0.9.15"))
+    }
+}

--- a/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
@@ -1,0 +1,48 @@
+package net.nightvision.plugin.services
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ScanServiceTest {
+
+    @Test
+    fun `scan started marker matches the CLI details record`() {
+        val output = """
+            INFO Scan Details
+            │ Scan ID: 4f1c2b0e-0000-4000-8000-000000000000
+        """.trimIndent()
+        assertTrue(ScanService.SCAN_STARTED.containsMatchIn(output))
+    }
+
+    @Test
+    fun `scan started marker does not match ordinary progress output`() {
+        assertFalse(ScanService.SCAN_STARTED.containsMatchIn("INFO Connecting to relay"))
+    }
+
+    @Test
+    fun `message reports the CLI stderr when the scan never starts`() {
+        val message = ScanService.noScanStartedMessage("", "target not found in project")
+        assertTrue(message.contains("target not found in project"))
+    }
+
+    @Test
+    fun `message reports CLI output printed to stdout`() {
+        // The CLI prints several fatal errors to stdout rather than logging
+        // them, so a message built from stderr alone would be empty here.
+        val message = ScanService.noScanStartedMessage("could not set up the relay tunnel", "")
+        assertTrue(message.contains("could not set up the relay tunnel"))
+    }
+
+    @Test
+    fun `message stands alone when the CLI reported nothing at all`() {
+        val message = ScanService.noScanStartedMessage("", "")
+        assertTrue(message.contains("without reporting a reason"))
+    }
+
+    @Test
+    fun `stderr wins over stdout when both carry text`() {
+        val message = ScanService.noScanStartedMessage("progress chatter", "the real reason")
+        assertTrue(message.contains("the real reason"))
+        assertFalse(message.contains("progress chatter"))
+    }
+}

--- a/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
@@ -56,7 +56,7 @@ class ScanServiceTest {
     @Test
     fun `message stands alone when the CLI reported nothing at all`() {
         val message = ScanService.noScanStartedMessage("", "")
-        assertTrue(message.contains("without reporting a reason"))
+        assertTrue(message.contains("reported no reason"))
     }
 
     @Test

--- a/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
@@ -65,4 +65,29 @@ class ScanServiceTest {
         assertTrue(message.contains("the real reason"))
         assertFalse(message.contains("progress chatter"))
     }
+
+    @Test
+    fun `scan command passes the target as its own argument`() {
+        val cmd = ScanService.buildScanCommand("my target with spaces", null)
+        assertEquals(listOf("nightvision", "scan", "my target with spaces"), cmd)
+    }
+
+    @Test
+    fun `scan command carries the authentication when one is chosen`() {
+        val cmd = ScanService.buildScanCommand("t", "my-auth")
+        assertEquals(listOf("nightvision", "scan", "t", "--auth", "my-auth"), cmd)
+    }
+
+    @Test
+    fun `scan command omits the auth flag when no authentication is chosen`() {
+        assertEquals(listOf("nightvision", "scan", "t"), ScanService.buildScanCommand("t", null))
+    }
+
+    @Test
+    fun `scan command omits the auth flag for the combo box empty entry`() {
+        // The create-scan combo carries an empty entry when the project has no
+        // authentications; that must not become an --auth with an empty value.
+        assertEquals(listOf("nightvision", "scan", "t"), ScanService.buildScanCommand("t", ""))
+        assertEquals(listOf("nightvision", "scan", "t"), ScanService.buildScanCommand("t", "   "))
+    }
 }

--- a/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
+++ b/src/test/kotlin/net/nightvision/plugin/services/ScanServiceTest.kt
@@ -1,5 +1,6 @@
 package net.nightvision.plugin.services
 
+import net.nightvision.plugin.exceptions.NotLoggedException
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -12,6 +13,25 @@ class ScanServiceTest {
             │ Scan ID: 4f1c2b0e-0000-4000-8000-000000000000
         """.trimIndent()
         assertTrue(ScanService.SCAN_STARTED.containsMatchIn(output))
+    }
+
+    @Test
+    fun `timeout message carries what the CLI printed before it hung`() {
+        val message = ScanService.startupTimedOutMessage(
+            120_000L, "ERROR token has expired. Please try to log in again\n")
+        assertTrue("got: $message", message.contains("token has expired"))
+        // The caller routes on the message text, so the words have to survive.
+        assertEquals(
+            NotLoggedException::class.java,
+            CommandRunnerService.getSpecificRuntimeException(
+                listOf("nightvision", "scan"), RuntimeException(message)).javaClass)
+    }
+
+    @Test
+    fun `timeout message stands alone when the CLI printed nothing`() {
+        val message = ScanService.startupTimedOutMessage(120_000L, "   ")
+        assertTrue("got: $message", message.contains("did not start a scan within 120 seconds"))
+        assertFalse("got: $message", message.trimEnd().endsWith("\n"))
     }
 
     @Test


### PR DESCRIPTION
Scans could not complete at all: `startScan` ran the CLI through `runCommandSync`, whose 30 second default applied to the whole run, and destroying the process makes the CLI call `ScanKill`, so the plugin was cancelling healthy scans server-side and reporting a timeout. The deadline now bounds startup only, and the failures that genuinely stop a scan starting are reported with the CLI's own output, which is the defect the VS Code extension shipped as NV-4827 in v1.0.7. The rest of the branch carries over the remaining v1.0.7 changes: the CLI version floor, the resolved binary path, and Node 24 runtimes.

## Implementation

- **Report CLI failures that stop a scan starting**: falls back to stdout, drops the CLI's INFO narration so the reason is what shows, and holds the create-scan page until the scan starts ([NV-4885](https://nightvision.atlassian.net/browse/NV-4885)).
- **Bound scan startup instead of the whole run**: `runCommandUntilStarted` returns on the scan-details record and leaves the process running; its tests spawn real processes.
- **Do not send the CLI an `--auth` with an empty value**: the create-scan combo carries an empty entry when the project holds no authentications.
- **Raise the minimum CLI version off 0.9.5**: floor moves to 0.15.0, the oldest version observed to scan a target that is not reachable from the internet ([NV-4872](https://nightvision.atlassian.net/browse/NV-4872)).
- **Show which `nightvision` binary the plugin resolved**: the version mismatch and resolved path are stated beside the Update CLI button and in its tooltip, since the plugin's own copy leads `PATH` ([NV-4873](https://nightvision.atlassian.net/browse/NV-4873)).
- **Move GitHub Actions off end-of-life Node runtimes**: `actions/checkout` v7.0.1, `actions/setup-java` v5.7.0, `release-drafter` v7.7.0, all on node24 ([NV-4884](https://nightvision.atlassian.net/browse/NV-4884)).
- **Report the CLI reason when a create command produces no record**: project, target and authentication creation shared one generic message and a TODO.
- **Record the scan reliability fixes in the changelog**: `CHANGELOG.md` is the single source the Marketplace change notes are rendered from.
- **Let error messages be selected and copied**: `JBLabel.setCopyable` on every error label, so a CLI failure can be pasted into a support ticket.
- **Color the scan list severity dots**: one `dot.svg` served all five severities; Medium is brightened off the shared palette, and the tooltip names each severity with its count.
- **Stop "open in browser" links opening the home page**: `getUrlFor` appended a trailing slash to every URL it built; the slash now belongs to `getApiUrlFor` alone.
- **Word a failed command for the person who clicked it**: a non-zero exit said "The command failed (exit=1)" beside the friendly wording the exit-0 path got from [NV-4827](https://nightvision.atlassian.net/browse/NV-4827).
- **Switch project off the EDT**: the project dropdown ran the CLI on the event dispatch thread, freezing the IDE and raising an "IDE error" ([NV-4921](https://nightvision.atlassian.net/browse/NV-4921)).
- **Stop reading a no-op project switch as a failure**: the CLI has two success messages for `project set` and only one was matched, so re-selecting the current project looked like an error.
- **Let a scan run with no authentication in any project**: the optional authentication field offered no empty entry unless the project had none, forcing the first in the list onto every scan.
- **Bump the version to 2.3.0**: at 2.2.1 the change notes matched the already-published 2.2.1 section and rendered its two bullets in place of this branch's fifteen.

## Out-of-scope

- No Jira commit sync here, unlike the sibling repos. A public repository cannot call a reusable workflow stored in an internal one, so the callers were removed from this branch; see [NV-4883](https://nightvision.atlassian.net/browse/NV-4883). Ticket updates for this repo are manual.
- NV-4872 and NV-4873 stay open: each asks for a mechanism that holds across both IDE plugins, and this branch only corrects the stale values in this one.
- No dependency work: this repo has no open Dependabot security alerts. The branch supersedes Actions PRs #18, #21 and #22; the Gradle wrapper, Kotlin and IntelliJ Platform bumps (#23, #20, #17) are left alone.
